### PR TITLE
Support generators for withtype in datatype

### DIFF
--- a/CompareGen.sml
+++ b/CompareGen.sml
@@ -330,17 +330,17 @@ struct
                val argDups = findDuplicates args
                val () = AtomTable.insert dups (tyconA, argDups)
                val substMap = buildSubstMap env' (Token.toString tycon) varExps
-               val constrs =
-                 case tyconData env' tyconA of
-                   Databind constrs => List.map (substConstr substMap) constrs
-                 | Typebind _ => raise Fail "expected databind"
              in
                ( true
                , Pat.Const tycon
                , singleFnExp
                    (destructTuplePat
                       (applyDuplicates (argDups, Pat.Const, args)))
-                   (genConstrs (env, constrs))
+                   (case tyconData env' tyconA of
+                      Databind constrs =>
+                        genConstrs
+                          (env, List.map (substConstr substMap) constrs)
+                    | Typebind ty => tyExp env (subst substMap ty))
                )
              end) (ListPair.zip (tycons, tys))
       val concatTys = mkToken (String.concatWith "_"

--- a/CompareGen.sml
+++ b/CompareGen.sml
@@ -340,7 +340,7 @@ struct
                       Databind constrs =>
                         genConstrs
                           (env, List.map (substConstr substMap) constrs)
-                    | Typebind ty => tyExp env (subst substMap ty))
+                    | Typebind ty => tyExp' env (subst substMap ty))
                )
              end) (ListPair.zip (tycons, tys))
       val concatTys = mkToken (String.concatWith "_"

--- a/FruGen.sml
+++ b/FruGen.sml
@@ -76,7 +76,7 @@ struct
            decs)
     end
 
-  fun genDatabind ({elems, ...}: Ast.Exp.datbind) =
+  fun genDatabind ({elems, ...}: Ast.Exp.datbind) _ =
     let
       open BuildAst
       val elems = ArraySlice.foldr (op::) [] elems

--- a/GenericGen.sml
+++ b/GenericGen.sml
@@ -236,13 +236,12 @@ struct
                      let
                        val tycon = Token.toString tycon
                        val substMap = buildSubstMap env tycon varExps
-                       val constrs =
-                         case tyconData env (Atom.atom tycon) of
-                           Databind constrs =>
-                             List.map (substConstr substMap) constrs
-                         | Typebind _ => raise Fail "expected databind"
                      in
-                       genConstrs (env, constrs)
+                       case tyconData env (Atom.atom tycon) of
+                         Databind constrs =>
+                           genConstrs
+                             (env, List.map (substConstr substMap) constrs)
+                       | Typebind ty => genTy env (subst substMap ty)
                      end) tycons
             in
               singleLetExp genericDec (infixLExp andTok exps)
@@ -266,16 +265,15 @@ struct
                        val () = AtomTable.insert dups (tyconA, argDups)
                        val substMap =
                          buildSubstMap env (Token.toString tycon) varExps
-                       val constrs =
-                         case tyconData env tyconA of
-                           Databind constrs =>
-                             List.map (substConstr substMap) constrs
-                         | Typebind _ => raise Fail "expected databind"
                      in
                        singleFunDec tycon
                          [destructTuplePat
                             (applyDuplicates (argDups, Pat.Const, args))]
-                         (genConstrs (env, constrs))
+                         (case tyconData env tyconA of
+                            Databind constrs =>
+                              genConstrs
+                                (env, List.map (substConstr substMap) constrs)
+                          | Typebind ty => genTy env (subst substMap ty))
                      end) (ListPair.zip (tycons, tys))
               val exps =
                 List.map

--- a/MutRecTy.sig
+++ b/MutRecTy.sig
@@ -36,6 +36,7 @@ sig
     (env * Token.token * Token.token list * type_data -> Ast.Exp.dec)
     * (env * Token.token list * Ast.Ty.ty list * Token.token list -> Ast.Exp.dec)
     -> Ast.Exp.datbind
+    -> Ast.Exp.typbind option
     -> Ast.Exp.dec
   val genSingleTypebind: (Ast.Exp.typbind -> Ast.Exp.dec)
                          -> Token.token * Token.token list * Ast.Ty.ty

--- a/MutRecTy.sig
+++ b/MutRecTy.sig
@@ -2,6 +2,8 @@ signature MUT_REC_TY =
 sig
   type env
 
+  datatype type_data = Databind of BuildAst.constr list | Typebind of Ast.Ty.ty
+
   val mkEnv: unit -> env
   val envWithVars: Token.token list -> env -> env
 
@@ -16,7 +18,7 @@ sig
   val generatedArgsForTy: env -> Ast.Ty.ty -> Ast.Ty.ty list
   val generatedFixesAndArgs: env -> (Token.token * Ast.Ty.ty list) list
   val tyconIsGeneratedFix: env -> string -> bool
-  val tyconConstrs: env -> Atom.atom -> Utils.constr list
+  val tyconData: env -> Atom.atom -> type_data
 
   val baseTyName: string -> string
 
@@ -31,8 +33,11 @@ sig
 
   val maxTySize: int ref
   val genDatabindHelper:
-    (env * Token.token * Token.token list * Utils.constr list -> Ast.Exp.dec)
+    (env * Token.token * Token.token list * type_data -> Ast.Exp.dec)
     * (env * Token.token list * Ast.Ty.ty list * Token.token list -> Ast.Exp.dec)
     -> Ast.Exp.datbind
     -> Ast.Exp.dec
+  val genSingleTypebind: (Ast.Exp.typbind -> Ast.Exp.dec)
+                         -> Token.token * Token.token list * Ast.Ty.ty
+                         -> Ast.Exp.dec
 end

--- a/MutRecTy.sml
+++ b/MutRecTy.sml
@@ -5,6 +5,8 @@ struct
   structure SCC =
     GraphSCCFn (struct type ord_key = int val compare = Int.compare end)
 
+  datatype type_data = Databind of constr list | Typebind of Ty.ty
+
   datatype env =
     Env of
       { tyToFix: Token.token AtomTable.hash_table
@@ -12,7 +14,7 @@ struct
       , fixToTy: Ty.ty AtomTable.hash_table
       , vars: Token.token list
       , tyTokToId: int AtomTable.hash_table
-      , tyData: (Token.token * Token.token SyntaxSeq.t * constr list) IntHashTable.hash_table
+      , tyData: (Token.token * Token.token SyntaxSeq.t * type_data) IntHashTable.hash_table
       , c: int ref
       }
 
@@ -154,9 +156,8 @@ struct
     (env as Env {c, tyTokToId, tyData, tyToFix, fixToTy, ...}, tycon, substMap) =
     let
       val i = AtomTable.lookup tyTokToId (Atom.atom tycon)
-      val (_, vars, constrs) = IntHashTable.lookup tyData i
+      val (_, vars, dat) = IntHashTable.lookup tyData i
       val ty = subst substMap (tyconToTy (env, tycon))
-      val constrs = List.map (substConstr substMap) constrs
       val tyStrA = Atom.atom (showTy ty)
     in
       if AtomTable.inDomain tyToFix tyStrA then
@@ -205,7 +206,11 @@ struct
                 (go from; go to)
             | go (Ty.Parens {ty, ...}) = go ty
         in
-          List.app (fn {arg = SOME {ty, ...}, ...} => go ty | _ => ()) constrs
+          case dat of
+            Databind constrs =>
+              List.app (fn {arg = SOME {ty, ...}, ...} => go ty | _ => ())
+                (List.map (substConstr substMap) constrs)
+          | Typebind ty => go (subst substMap ty)
         end
     end
 
@@ -222,7 +227,7 @@ struct
   fun tyconIsGeneratedFix (Env {fixToTy, ...}) tycon =
     AtomTable.inDomain fixToTy (Atom.atom tycon)
 
-  fun tyconConstrs (Env {tyTokToId, tyData, ...}) tyconAtom =
+  fun tyconData (Env {tyTokToId, tyData, ...}) tyconAtom =
     let
       val i = AtomTable.lookup tyTokToId tyconAtom
       val (_, _, constrs) = IntHashTable.lookup tyData i
@@ -345,16 +350,19 @@ struct
                val () = AtomTable.insert tyTokToId
                  (Atom.atom (Token.toString ty), i)
                val () = IntHashTable.insert tyLinks (i, IntListSet.empty)
-               val () = IntHashTable.insert tyData (i, (ty, vars, constrs))
+               val () = IntHashTable.insert tyData
+                 (i, (ty, vars, Databind constrs))
              in
                i
              end) tys
+      (* TODO: Initialize tyLinks and tyData for withtype types also *)
       val () =
         List.app
           (fn (i, (_, _, constrs)) =>
              List.app
                (fn {arg = SOME {ty, ...}, ...} => buildLinks i ty | _ => ())
                constrs) (ListPair.zip (roots, tys))
+      (* TODO: Build links for withtype types also *)
       val scc = SCC.topOrder'
         { roots = roots
         , follow = IntListSet.toList o IntHashTable.lookup tyLinks
@@ -397,5 +405,14 @@ struct
               (print "Max type size limit exceeded\n"; DecEmpty)
     in
       multDec (List.map handleComponent (List.rev scc))
+    end
+  fun genSingleTypebind genTypebind (tyTok, vars, ty) =
+    let
+      val elem =
+        {eq = equalTok, tycon = tyTok, ty = ty, tyvars = listToSyntaxSeq vars}
+      val bind: typbind =
+        {elems = Seq.fromList [elem], delims = Seq.fromList []}
+    in
+      genTypebind bind
     end
 end

--- a/ShowGen.sml
+++ b/ShowGen.sml
@@ -230,7 +230,7 @@ struct
                       Databind constrs =>
                         genConstrs
                           (env, List.map (substConstr substMap) constrs)
-                    | Typebind ty => tyExp env (subst substMap ty))
+                    | Typebind ty => tyExp' env (subst substMap ty))
                )
              end) (ListPair.zip (tycons, tys))
       val concatTys = mkToken (String.concatWith "_"

--- a/ShowGen.sml
+++ b/ShowGen.sml
@@ -220,17 +220,17 @@ struct
                val argDups = findDuplicates args
                val () = AtomTable.insert dups (tyconA, argDups)
                val substMap = buildSubstMap env' (Token.toString tycon) varExps
-               val constrs =
-                 case tyconData env' tyconA of
-                   Databind constrs => List.map (substConstr substMap) constrs
-                 | Typebind _ => raise Fail "expected databind"
              in
                ( true
                , Pat.Const tycon
                , singleFnExp
                    (destructTuplePat
                       (applyDuplicates (argDups, Pat.Const, args)))
-                   (genConstrs (env, constrs))
+                   (case tyconData env' tyconA of
+                      Databind constrs =>
+                        genConstrs
+                          (env, List.map (substConstr substMap) constrs)
+                    | Typebind ty => tyExp env (subst substMap ty))
                )
              end) (ListPair.zip (tycons, tys))
       val concatTys = mkToken (String.concatWith "_"

--- a/ShowGen.sml
+++ b/ShowGen.sml
@@ -185,18 +185,20 @@ struct
       localDecs (additionalDecs env) (multDec decs)
     end
 
-  fun genSimpleDatabind (env, ty, vars, constrs) =
-    let
-      val env = Env.empty env
-      fun header exp =
-        case List.map (Pat.Const o mkTyVar) vars of
-          [] => exp
-        | vars => singleFnExp (destructTuplePat vars) exp
-      val dec = valDec (Pat.Const (mkShow ty)) (header
-        (genConstrs (env, constrs)))
-    in
-      localDecs (additionalDecs env) dec
-    end
+  fun genSimpleDatabind (env, ty, vars, Databind constrs) =
+        let
+          val env = Env.empty env
+          fun header exp =
+            case List.map (Pat.Const o mkTyVar) vars of
+              [] => exp
+            | vars => singleFnExp (destructTuplePat vars) exp
+          val dec = valDec (Pat.Const (mkShow ty)) (header
+            (genConstrs (env, constrs)))
+        in
+          localDecs (additionalDecs env) dec
+        end
+    | genSimpleDatabind (_, tyTok, vars, Typebind ty) =
+        genSingleTypebind genTypebind (tyTok, vars, ty)
 
   fun genRecursiveDatabind (env, tycons, tys, vars) =
     let
@@ -218,8 +220,10 @@ struct
                val argDups = findDuplicates args
                val () = AtomTable.insert dups (tyconA, argDups)
                val substMap = buildSubstMap env' (Token.toString tycon) varExps
-               val constrs = List.map (substConstr substMap)
-                 (tyconConstrs env' tyconA)
+               val constrs =
+                 case tyconData env' tyconA of
+                   Databind constrs => List.map (substConstr substMap) constrs
+                 | Typebind _ => raise Fail "expected databind"
              in
                ( true
                , Pat.Const tycon

--- a/Utils.sml
+++ b/Utils.sml
@@ -34,6 +34,16 @@ struct
     | syntaxSeqToList (SyntaxSeq.Many {elems, ...}) =
         ArraySlice.foldr (op::) [] elems
 
+  fun listToSyntaxSeq [] = SyntaxSeq.Empty
+    | listToSyntaxSeq [e] = SyntaxSeq.One e
+    | listToSyntaxSeq (elems as (_ :: es)) =
+        SyntaxSeq.Many
+          { left = openParenTok
+          , right = closeParenTok
+          , elems = Seq.fromList elems
+          , delims = Seq.fromList (List.map (fn _ => commaTok) es)
+          }
+
   fun syntaxSeqMap _ SyntaxSeq.Empty = SyntaxSeq.Empty
     | syntaxSeqMap f (SyntaxSeq.One e) =
         SyntaxSeq.One (f e)

--- a/test/test16.sh
+++ b/test/test16.sh
@@ -1,0 +1,9 @@
+../smlgen --test test16.sml t:gsc
+if cmp --silent test16.sml.test test16.sml.expected; then
+  echo "test16 succeeded"
+else
+  echo "test16 failed"
+  echo "Diff:"
+  diff test16.sml.test test16.sml.expected
+  exit 1
+fi

--- a/test/test16.sml
+++ b/test/test16.sml
@@ -1,0 +1,20 @@
+(* non-recursive withtype & non-recursive datatype *)
+datatype t = T' of int * string | Nil
+withtype t' = t * int
+
+val () = print (showT' (T' (1, "hello"), 2) ^ "\n")
+
+(* non-recursive withtype with recursive datatype *)
+datatype t = T' of string * t | T'' of t * t | Nil
+withtype t' = { t: t, other: string }
+
+val () = print (showT' {t = T' ("hello", T'' (Nil, Nil)), other = "world"} ^ "\n")
+
+(* recursive withtype with recursive datatype *)
+datatype t = T' of string * t' | Nil
+withtype t' = t list
+
+val () = print (showT' [T' ("hello", [T' ("world", []), Nil]), T' ("foo", [Nil]), Nil] ^ "\n")
+
+(* TODO: test with type variables *)
+(* TODO: test with multiple types in withtype *)

--- a/test/test16.sml
+++ b/test/test16.sml
@@ -1,3 +1,5 @@
+infix & *` +`
+
 (* non-recursive withtype & non-recursive datatype *)
 datatype t = T' of int * string | Nil
 withtype t' = t * int
@@ -16,5 +18,22 @@ withtype t' = t list
 
 val () = print (showT' [T' ("hello", [T' ("world", []), Nil]), T' ("foo", [Nil]), Nil] ^ "\n")
 
-(* TODO: test with type variables *)
-(* TODO: test with multiple types in withtype *)
+(* test with type variables *)
+
+datatype 'a t = T' of 'a t' | Nil
+withtype 'b t' = 'b * 'b t list
+
+val () = print (showT' Int.toString (1, [Nil, T' (2, [Nil])]) ^ "\n")
+
+datatype ('a, 'b) t = T' of 'a t' * 'b t' | Nil
+withtype 'b t' = 'b * ('b, 'b) t
+
+val () = print (show (Int.toString, fn a => a) (T' ((1, T' ((2, Nil), (3, Nil))), ("a", T' (("b", Nil), ("c", Nil)))))  ^ "\n")
+
+(* test with multiple types in withtype *)
+
+datatype ('a, 'b) t = T' of 'a t' * 'b t'' | Nil
+withtype 'a t' = 'a * ('a, int) t
+and 'a t'' = (string, 'a) t * 'a
+
+val () = print (show (fn a => a, Int.toString) (T' (("a", T' (("b", Nil), (Nil, 1))), (T' (("c", Nil), (Nil, 3)), 2))) ^ "\n")

--- a/test/test16.sml.expected
+++ b/test/test16.sml.expected
@@ -1,0 +1,165 @@
+(* non-recursive withtype & non-recursive datatype *)
+datatype t =
+  T' of int * string
+| Nil
+withtype t' = t * int
+val t =
+  let
+    open Generic
+  in
+    data' (C1' "T'" (tuple2 (int, string)) +` C0' "Nil")
+      (fn Nil => INR () | T' ? => INL ?, fn INR () => Nil | INL ? => T' ?)
+  end
+val t' = let open Generic in tuple2 (t, int) end
+val show =
+  fn T' (t0, t1) =>
+    "T' " ^ "(" ^ String.concatWith ", " [Int.toString t0, "\"" ^ t1 ^ "\""]
+    ^ ")"
+   | Nil => "Nil"
+val showT' = fn (t0, t1) =>
+  "(" ^ String.concatWith ", " [show t0, Int.toString t1] ^ ")"
+val compare =
+  fn (T' (t0, t1), T' (t2, t3)) =>
+    (case Int.compare (t0, t2) of
+       EQUAL => String.compare (t1, t3)
+     | ? => ?)
+   | (T' _, Nil) => LESS
+   | (Nil, T' _) => GREATER
+   | (Nil, Nil) => EQUAL
+val compareT' = fn ((t0, t1), (t2, t3)) =>
+  (case compare (t0, t2) of
+     EQUAL => Int.compare (t1, t3)
+   | ? => ?)
+
+val () = print (showT' (T' (1, "hello"), 2) ^ "\n")
+
+(* non-recursive withtype with recursive datatype *)
+datatype t =
+  T' of string * t
+| T'' of t * t
+| Nil
+withtype t' = {t: t, other: string}
+val t =
+  let
+    open Tie
+    val Y = Generic.Y
+  in
+    fix Y (fn t =>
+      let
+        open Generic
+      in
+        data'
+          (C1' "T'" (tuple2 (string, t)) +` C1' "T''" (tuple2 (t, t))
+           +` C0' "Nil")
+          ( fn Nil => INR () | T'' ? => INL (INR ?) | T' ? => INL (INL ?)
+          , fn INR () => Nil | INL (INR ?) => T'' ? | INL (INL ?) => T' ?
+          )
+      end)
+  end
+val t' =
+  let
+    open Generic
+  in
+    record' (R' "t" t *` R' "other" string)
+      (fn {t, other} => t & other, fn t & other => {t = t, other = other})
+  end
+local
+  val rec t = fn t_0 =>
+    fn T' (t0, t1) =>
+      "T' " ^ "(" ^ String.concatWith ", " ["\"" ^ t0 ^ "\"", t_0 t1] ^ ")"
+     | T'' (t2, t3) =>
+      "T'' " ^ "(" ^ String.concatWith ", " [t_0 t2, t_0 t3] ^ ")"
+     | Nil => "Nil"
+  val t = fn () => let val rec t_0 = fn ? => t t_0 ? in t_0 end
+in val show = t ()
+end
+val showT' = fn {t = t0, other = t1} =>
+  "{" ^ String.concatWith ", " ["t = " ^ show t0, "other = " ^ "\"" ^ t1 ^ "\""]
+  ^ "}"
+local
+  val rec t = fn t_0 =>
+    fn (T' (t0, t1), T' (t2, t3)) =>
+      (case String.compare (t0, t2) of
+         EQUAL => t_0 (t1, t3)
+       | ? => ?)
+     | (T' _, T'' _) => LESS
+     | (T' _, Nil) => LESS
+     | (T'' _, T' _) => GREATER
+     | (T'' (t4, t5), T'' (t6, t7)) =>
+      (case t_0 (t4, t6) of
+         EQUAL => t_0 (t5, t7)
+       | ? => ?)
+     | (T'' _, Nil) => LESS
+     | (Nil, T' _) => GREATER
+     | (Nil, T'' _) => GREATER
+     | (Nil, Nil) => EQUAL
+  val t = fn () => let val rec t_0 = fn ? => t t_0 ? in t_0 end
+in val compare = t ()
+end
+val compareT' = fn ({t = t0, other = t1}, {t = t2, other = t3}) =>
+  (case compare (t0, t2) of
+     EQUAL => String.compare (t1, t3)
+   | ? => ?)
+
+val () = print
+  (showT' {t = T' ("hello", T'' (Nil, Nil)), other = "world"} ^ "\n")
+
+(* recursive withtype with recursive datatype *)
+datatype t =
+  T' of string * t'
+| Nil
+withtype t' = t list
+val t' & t =
+  let
+    open Tie
+    val Y = Generic.Y
+  in
+    fix (Y *` Y) (fn t' & t =>
+      let
+        open Generic
+      in
+        list t
+        &
+        data' (C1' "T'" (tuple2 (string, t')) +` C0' "Nil")
+          (fn Nil => INR () | T' ? => INL ?, fn INR () => Nil | INL ? => T' ?)
+      end)
+  end
+local
+  val rec t' = fn t_1 =>
+    fn t0 => "[" ^ String.concatWith ", " (List.map t_1 t0) ^ "]"
+  and rec t = fn t'_0 =>
+    fn T' (t0, t1) =>
+      "T' " ^ "(" ^ String.concatWith ", " ["\"" ^ t0 ^ "\"", t'_0 t1] ^ ")"
+     | Nil => "Nil"
+  val t'_t = fn () =>
+    let val rec t'_0 = fn ? => t' t_1 ? and rec t_1 = fn ? => t t'_0 ?
+    in (t'_0, t_1)
+    end
+in val showT' = #1 (t'_t ()) val show = #2 (t'_t ())
+end
+local
+  fun compareList cmp (x :: xs, y :: ys) =
+        (case cmp (x, y) of
+           EQUAL => compareList cmp (xs, ys)
+         | ? => ?)
+    | compareList _ (_ :: _, []) = GREATER
+    | compareList _ ([], _ :: _) = LESS
+    | compareList _ _ = EQUAL
+  val rec t' = fn t_1 => compareList t_1
+  and rec t = fn t'_0 =>
+    fn (T' (t0, t1), T' (t2, t3)) =>
+      (case String.compare (t0, t2) of
+         EQUAL => t'_0 (t1, t3)
+       | ? => ?)
+     | (T' _, Nil) => LESS
+     | (Nil, T' _) => GREATER
+     | (Nil, Nil) => EQUAL
+  val t'_t = fn () =>
+    let val rec t'_0 = fn ? => t' t_1 ? and rec t_1 = fn ? => t t'_0 ?
+    in (t'_0, t_1)
+    end
+in val compareT' = #1 (t'_t ()) val compare = #2 (t'_t ())
+end
+
+val () = print
+  (showT' [T' ("hello", [T' ("world", []), Nil]), T' ("foo", [Nil]), Nil] ^ "\n") (* TODO: test with type variables *) (* TODO: test with multiple types in withtype *)

--- a/test/test16.sml.expected
+++ b/test/test16.sml.expected
@@ -1,3 +1,5 @@
+infix & *` +`
+
 (* non-recursive withtype & non-recursive datatype *)
 datatype t =
   T' of int * string
@@ -162,4 +164,262 @@ in val compareT' = #1 (t'_t ()) val compare = #2 (t'_t ())
 end
 
 val () = print
-  (showT' [T' ("hello", [T' ("world", []), Nil]), T' ("foo", [Nil]), Nil] ^ "\n") (* TODO: test with type variables *) (* TODO: test with multiple types in withtype *)
+  (showT' [T' ("hello", [T' ("world", []), Nil]), T' ("foo", [Nil]), Nil] ^ "\n")
+
+(* test with type variables *)
+
+datatype 'a t =
+  T' of 'a t'
+| Nil
+withtype 'b t' = 'b * 'b t list
+val t'_t = fn b_ =>
+  let
+    open Tie
+    val Y = Generic.Y
+    val t'_0 & t_1 = fix (Y *` Y) (fn t'_0 & t_1 =>
+      let
+        open Generic
+        fun t' (t_1, b_) =
+          tuple2 (b_, list t_1)
+        fun t (t'_0, b_) =
+          data' (C1' "T'" t'_0 +` C0' "Nil")
+            (fn Nil => INR () | T' ? => INL ?, fn INR () => Nil | INL ? => T' ?)
+      in
+        t' (t_1, b_) & t (t'_0, b_)
+      end)
+  in
+    (t'_0, t_1)
+  end
+val t' = fn ? => #1 (t'_t ?)
+val t = fn ? => #2 (t'_t ?)
+local
+  val rec t' = fn (t_1, b_) =>
+    fn (t0, t1) =>
+      "("
+      ^
+      String.concatWith ", "
+        [b_ t0, "[" ^ String.concatWith ", " (List.map t_1 t1) ^ "]"] ^ ")"
+  and rec t = fn (t'_0, b_) =>
+    fn T' t0 => "T' " ^ "(" ^ t'_0 t0 ^ ")" | Nil => "Nil"
+  val t'_t = fn b_ =>
+    let
+      val rec t'_0 = fn ? => t' (t_1, b_) ?
+      and rec t_1 = fn ? => t (t'_0, b_) ?
+    in
+      (t'_0, t_1)
+    end
+in val showT' = fn ? => #1 (t'_t ?) val show = fn ? => #2 (t'_t ?)
+end
+local
+  fun compareList cmp (x :: xs, y :: ys) =
+        (case cmp (x, y) of
+           EQUAL => compareList cmp (xs, ys)
+         | ? => ?)
+    | compareList _ (_ :: _, []) = GREATER
+    | compareList _ ([], _ :: _) = LESS
+    | compareList _ _ = EQUAL
+  val rec t' = fn (t_1, b_) =>
+    fn ((t0, t1), (t2, t3)) =>
+      (case b_ (t0, t2) of
+         EQUAL => compareList t_1 (t1, t3)
+       | ? => ?)
+  and rec t = fn (t'_0, b_) =>
+    fn (T' t0, T' t1) => t'_0 (t0, t1)
+     | (T' _, Nil) => LESS
+     | (Nil, T' _) => GREATER
+     | (Nil, Nil) => EQUAL
+  val t'_t = fn b_ =>
+    let
+      val rec t'_0 = fn ? => t' (t_1, b_) ?
+      and rec t_1 = fn ? => t (t'_0, b_) ?
+    in
+      (t'_0, t_1)
+    end
+in val compareT' = fn ? => #1 (t'_t ?) val compare = fn ? => #2 (t'_t ?)
+end
+
+val () = print (showT' Int.toString (1, [Nil, T' (2, [Nil])]) ^ "\n")
+
+datatype ('a, 'b) t = T' of 'a t' * 'b t' | Nil
+withtype 'b t' = 'b * ('b, 'b) t
+val t'_t = fn (a_, b_) =>
+  let
+    open Tie
+    val Y = Generic.Y
+    val _ & _ & t'_0 & _ & t_2 =
+      fix (Y *` Y *` Y *` Y *` Y) (fn t'_3 & t_4 & t'_0 & t_1 & t_2 =>
+        let
+          open Generic
+          fun t' (t_1, a_) = tuple2 (a_, t_1)
+          fun t (t'_3, t'_0, b_, a_) =
+            data' (C1' "T'" (tuple2 (t'_0, t'_3)) +` C0' "Nil")
+              ( fn Nil => INR () | T' ? => INL ?
+              , fn INR () => Nil | INL ? => T' ?
+              )
+        in
+          t' (t_4, b_) & t (t'_3, t'_3, b_, b_) & t' (t_1, a_)
+          & t (t'_0, t'_0, a_, a_) & t (t'_3, t'_0, b_, a_)
+        end)
+  in
+    (t'_0, t_2)
+  end
+val t' = fn b_ => #1 (t'_t (b_, b_))
+val t = fn ? => #2 (t'_t ?)
+local
+  val rec t' = fn (t_1, a_) =>
+    fn (t0, t1) => "(" ^ String.concatWith ", " [a_ t0, t_1 t1] ^ ")"
+  and rec t = fn (t'_3, t'_0, b_, a_) =>
+    fn T' (t0, t1) =>
+      "T' " ^ "(" ^ String.concatWith ", " [t'_0 t0, t'_3 t1] ^ ")"
+     | Nil => "Nil"
+  val t'_t = fn (a_, b_) =>
+    let
+      val rec t'_3 = fn ? => t' (t_4, b_) ?
+      and rec t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
+      and rec t'_0 = fn ? => t' (t_1, a_) ?
+      and rec t_1 = fn ? => t (t'_0, t'_0, a_, a_) ?
+      and rec t_2 = fn ? => t (t'_3, t'_0, b_, a_) ?
+    in
+      (t'_0, t_2)
+    end
+in val showT' = fn b_ => #1 (t'_t (b_, b_)) val show = fn ? => #2 (t'_t ?)
+end
+local
+  val rec t' = fn (t_1, a_) =>
+    fn ((t0, t1), (t2, t3)) =>
+      (case a_ (t0, t2) of
+         EQUAL => t_1 (t1, t3)
+       | ? => ?)
+  and rec t = fn (t'_3, t'_0, b_, a_) =>
+    fn (T' (t0, t1), T' (t2, t3)) =>
+      (case t'_0 (t0, t2) of
+         EQUAL => t'_3 (t1, t3)
+       | ? => ?)
+     | (T' _, Nil) => LESS
+     | (Nil, T' _) => GREATER
+     | (Nil, Nil) => EQUAL
+  val t'_t = fn (a_, b_) =>
+    let
+      val rec t'_3 = fn ? => t' (t_4, b_) ?
+      and rec t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
+      and rec t'_0 = fn ? => t' (t_1, a_) ?
+      and rec t_1 = fn ? => t (t'_0, t'_0, a_, a_) ?
+      and rec t_2 = fn ? => t (t'_3, t'_0, b_, a_) ?
+    in
+      (t'_0, t_2)
+    end
+in val compareT' = fn b_ => #1 (t'_t (b_, b_)) val compare = fn ? => #2 (t'_t ?)
+end
+
+val () = print
+  (show (Int.toString, fn a => a) (T'
+     ((1, T' ((2, Nil), (3, Nil))), ("a", T' (("b", Nil), ("c", Nil))))) ^ "\n")
+
+(* test with multiple types in withtype *)
+
+datatype ('a, 'b) t =
+  T' of 'a t' * 'b t''
+| Nil
+withtype 'a t' = 'a * ('a, int) t
+and 'a t'' = (string, 'a) t * 'a
+val t''_t_t' = fn (a_, b_) =>
+  let
+    open Tie
+    val Y = Generic.Y
+    val _ & t'_6 & _ & _ & t_5 & _ & _ & t''_0 & _ & _ =
+      fix (Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y)
+        (fn t_7 & t'_6 & t''_8 & t''_4 & t_5 & t_9 & t_3 & t''_0 & t_1 & t'_2 =>
+           let
+             open Generic
+             fun t'' (t_1, a_) = tuple2 (t_1, a_)
+             fun t (t''_8, t'_6, b_, a_) =
+               data' (C1' "T'" (tuple2 (t'_6, t''_8)) +` C0' "Nil")
+                 ( fn Nil => INR () | T' ? => INL ?
+                 , fn INR () => Nil | INL ? => T' ?
+                 )
+             fun t' (t_7, a_) = tuple2 (a_, t_7)
+           in
+             t (t''_4, t'_6, int, a_) & t' (t_7, a_) & t'' (t_9, b_)
+             & t'' (t_3, int) & t (t''_8, t'_6, b_, a_)
+             & t (t''_8, t'_2, b_, string) & t (t''_4, t'_2, int, string)
+             & t'' (t_1, a_) & t (t''_0, t'_2, a_, string) & t' (t_3, string)
+           end)
+  in
+    (t''_0, t_5, t'_6)
+  end
+val t'' = fn a_ => #1 (t''_t_t' (a_, a_))
+val t = fn ? => #2 (t''_t_t' ?)
+val t' = fn a_ => #3 (t''_t_t' (a_, a_))
+local
+  val rec t'' = fn (t_1, a_) =>
+    fn (t0, t1) => "(" ^ String.concatWith ", " [t_1 t0, a_ t1] ^ ")"
+  and rec t = fn (t''_8, t'_6, b_, a_) =>
+    fn T' (t0, t1) =>
+      "T' " ^ "(" ^ String.concatWith ", " [t'_6 t0, t''_8 t1] ^ ")"
+     | Nil => "Nil"
+  and rec t' = fn (t_7, a_) =>
+    fn (t0, t1) => "(" ^ String.concatWith ", " [a_ t0, t_7 t1] ^ ")"
+  val t''_t_t' = fn (a_, b_) =>
+    let
+      val rec t_7 = fn ? => t (t''_4, t'_6, Int.toString, a_) ?
+      and rec t'_6 = fn ? => t' (t_7, a_) ?
+      and rec t''_8 = fn ? => t'' (t_9, b_) ?
+      and rec t''_4 = fn ? => t'' (t_3, Int.toString) ?
+      and rec t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
+      and rec t_9 = fn ? => t (t''_8, t'_2, b_, fn t0 => "\"" ^ t0 ^ "\"") ?
+      and rec t_3 = fn ? =>
+        t (t''_4, t'_2, Int.toString, fn t0 => "\"" ^ t0 ^ "\"") ?
+      and rec t''_0 = fn ? => t'' (t_1, a_) ?
+      and rec t_1 = fn ? => t (t''_0, t'_2, a_, fn t0 => "\"" ^ t0 ^ "\"") ?
+      and rec t'_2 = fn ? => t' (t_3, fn t0 => "\"" ^ t0 ^ "\"") ?
+    in
+      (t''_0, t_5, t'_6)
+    end
+in
+  val showT'' = fn a_ => #1 (t''_t_t' (a_, a_))
+  val show = fn ? => #2 (t''_t_t' ?)
+  val showT' = fn a_ => #3 (t''_t_t' (a_, a_))
+end
+local
+  val rec t'' = fn (t_1, a_) =>
+    fn ((t0, t1), (t2, t3)) =>
+      (case t_1 (t0, t2) of
+         EQUAL => a_ (t1, t3)
+       | ? => ?)
+  and rec t = fn (t''_8, t'_6, b_, a_) =>
+    fn (T' (t0, t1), T' (t2, t3)) =>
+      (case t'_6 (t0, t2) of
+         EQUAL => t''_8 (t1, t3)
+       | ? => ?)
+     | (T' _, Nil) => LESS
+     | (Nil, T' _) => GREATER
+     | (Nil, Nil) => EQUAL
+  and rec t' = fn (t_7, a_) =>
+    fn ((t0, t1), (t2, t3)) =>
+      (case a_ (t0, t2) of
+         EQUAL => t_7 (t1, t3)
+       | ? => ?)
+  val t''_t_t' = fn (a_, b_) =>
+    let
+      val rec t_7 = fn ? => t (t''_4, t'_6, Int.compare, a_) ?
+      and rec t'_6 = fn ? => t' (t_7, a_) ?
+      and rec t''_8 = fn ? => t'' (t_9, b_) ?
+      and rec t''_4 = fn ? => t'' (t_3, Int.compare) ?
+      and rec t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
+      and rec t_9 = fn ? => t (t''_8, t'_2, b_, String.compare) ?
+      and rec t_3 = fn ? => t (t''_4, t'_2, Int.compare, String.compare) ?
+      and rec t''_0 = fn ? => t'' (t_1, a_) ?
+      and rec t_1 = fn ? => t (t''_0, t'_2, a_, String.compare) ?
+      and rec t'_2 = fn ? => t' (t_3, String.compare) ?
+    in
+      (t''_0, t_5, t'_6)
+    end
+in
+  val compareT'' = fn a_ => #1 (t''_t_t' (a_, a_))
+  val compare = fn ? => #2 (t''_t_t' ?)
+  val compareT' = fn a_ => #3 (t''_t_t' (a_, a_))
+end
+
+val () = print
+  (show (fn a => a, Int.toString) (T'
+     (("a", T' (("b", Nil), (Nil, 1))), (T' (("c", Nil), (Nil, 3)), 2))) ^ "\n")


### PR DESCRIPTION
Adds support for withtype for all the generators (show, compare, and generic). It does this for `MutRecTy` by including the withtype types when finding the strongly connected components, and modifying the stored type data to distinguish between databinds and typebinds. Then each generator handles both the databind and the typebind case when generating code for databinds.