### PR TITLE
Hashes Ast.Ty.ty type for use in MutRecTy's hash tables

### DIFF
--- a/MutRecTy.sml
+++ b/MutRecTy.sml
@@ -119,9 +119,7 @@ struct
     )
 
   fun addTyArg (Env {tyToArgs, ...}) k v =
-    let val s = TyTable.lookup tyToArgs k handle LibBase.NotFound => []
-    in TyTable.insert tyToArgs (k, v :: s)
-    end
+    TyTable.insertWith (fn (v', v) => v @ v') tyToArgs (k, [v])
 
   fun buildSubstMap (Env {tyTokToId, tyData, ...}) tycon tys =
     let

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ to build the project in MLton.
 To build the project in Poly/ML, run:
 
 ```
+./build_polyml.sh
 polyc build.sml -o smlgen
 ```
+(MLton libraries are required to be in `/usr/local/lib/mlton` or `/usr/lib/mlton` for this to work)
 
 To build the project in MLKit, run:
 
@@ -44,7 +46,7 @@ to build a SML/NJ heap image file that looks something like `smlgen.amd64-linux`
 depending on the target architecture and OS. Then to run this heap image, run:
 
 ```
-sml @SMLload smlgen.amd64-linux <args>
+sml @SMLload=smlgen.amd64-linux <args>
 ```
 
 where `<args>` is the command line arguments to smlgen.

--- a/RecMod.sml
+++ b/RecMod.sml
@@ -375,7 +375,7 @@ struct
              ; print ") "
              ; print (Token.toString tycon)
              ; print " = "
-             ; print (Utils.showTy ty)
+             ; print (Utils.prettyTy ty)
              ; print "\n"
              )) elems
       ; print "]\n"

--- a/SmlfmtWrappers.sml
+++ b/SmlfmtWrappers.sml
@@ -1,14 +1,6 @@
 structure HashUtils =
 struct
   val combine = fn (a, b) => 0w31 * a + b
-  fun hashList _ [] = 0wx6D52A54D
-    | hashList hash l =
-        List.foldl (fn (i, acc) => combine (acc, hash i))
-          (Word.fromInt (List.length l)) l
-  fun eqList eq (x :: xs, y :: ys) =
-        eq (x, y) andalso eqList eq (xs, ys)
-    | eqList _ ([], []) = true
-    | eqList _ _ = false
   val hashString =
     #1
     o
@@ -24,8 +16,15 @@ struct
   open Seq
   local open HashUtils
   in
-    val hash = fn a_ => hashList a_ o Seq.toList
-    val op== = fn a_ => fn (l1, l2) => eqList a_ (Seq.toList l1, Seq.toList l2)
+    fun hash a_ s =
+      case Seq.length s of
+        0 => 0wx6D52A54D
+      | n =>
+          ArraySlice.foldl (fn (i, acc) => combine (acc, a_ i)) (Word.fromInt n)
+            s
+    fun op== a_ (l1, l2) =
+      Seq.length l1 = Seq.length l2
+      andalso ArraySlice.all (fn a => a) (Seq.zipWith a_ (l1, l2))
   end
 end
 

--- a/SmlfmtWrappers.sml
+++ b/SmlfmtWrappers.sml
@@ -1,0 +1,179 @@
+structure HashUtils =
+struct
+  val combine = fn (a, b) => 0w31 * a + b
+  fun hashList _ [] = 0wx6D52A54D
+    | hashList hash l =
+        List.foldl (fn (i, acc) => combine (acc, hash i))
+          (Word.fromInt (List.length l)) l
+  fun eqList eq (x :: xs, y :: ys) =
+        eq (x, y) andalso eqList eq (xs, ys)
+    | eqList _ ([], []) = true
+    | eqList _ _ = false
+  val hashString =
+    #1
+    o
+    Substring.foldl
+      (fn (ch, (h, p)) =>
+         ( Word.mod (h + Word.fromInt (Char.ord ch + 1) * p, 0w1000000009)
+         , Word.mod (p * 0w31, 0w1000000009)
+         )) (0w0, 0w1) o Substring.full
+end
+
+structure Seq =
+struct
+  open Seq
+  local open HashUtils
+  in
+    val hash = fn a_ => hashList a_ o Seq.toList
+    val op== = fn a_ => fn (l1, l2) => eqList a_ (Seq.toList l1, Seq.toList l2)
+  end
+end
+
+structure Token =
+struct
+  open Token
+  val op== = Token.same
+  local open HashUtils
+  in val hash = hashString o Token.toString
+  end
+end
+
+structure MaybeLongToken =
+struct
+  open MaybeLongToken
+  val op== = fn (a, b) => Token.== (getToken a, getToken b)
+  val hash = Token.hash o getToken
+end
+
+structure Ast =
+struct
+  open Ast
+  structure SyntaxSeq =
+  struct
+    open SyntaxSeq
+    local open HashUtils
+    in
+      val hash = fn a_ =>
+        fn Empty => hashString "Empty"
+         | One t0 => combine (hashString "One", a_ t0)
+         | Many {left = t1, elems = t2, delims = t3, right = t4} =>
+          let
+            val result = hashString "Many"
+            val result = combine (result, Token.hash t1)
+            val result = combine (result, Seq.hash a_ t2)
+            val result = combine (result, Seq.hash Token.hash t3)
+            val result = combine (result, Token.hash t4)
+          in
+            result
+          end
+    end
+    val op== = fn a_ =>
+      fn (Empty, Empty) => true
+       | (One t0, One t1) => a_ (t0, t1)
+       | ( Many {left = t2, elems = t3, delims = t4, right = t5}
+         , Many {left = t6, elems = t7, delims = t8, right = t9}
+         ) =>
+        Token.== (t2, t6) andalso Seq.== a_ (t3, t7)
+        andalso Seq.== Token.== (t4, t8) andalso Token.== (t5, t9)
+       | _ => false
+  end
+
+  structure Ty =
+  struct
+    open Ty
+    local
+      open HashUtils
+      val rec ty = fn ty_0 =>
+        fn Var t0 => combine (hashString "Var", Token.hash t0)
+         | Record {left = t1, elems = t2, delims = t3, right = t4} =>
+          let
+            val result = hashString "Record"
+            val result = combine (result, Token.hash t1)
+            val result = combine
+              ( result
+              , Seq.hash
+                  (fn {lab = t0, colon = t1, ty = t2} =>
+                     let
+                       val result = Token.hash t0
+                       val result = combine (result, Token.hash t1)
+                       val result = combine (result, ty_0 t2)
+                     in
+                       result
+                     end) t2
+              )
+            val result = combine (result, Seq.hash Token.hash t3)
+            val result = combine (result, Token.hash t4)
+          in
+            result
+          end
+         | Tuple {elems = t5, delims = t6} =>
+          let
+            val result = hashString "Tuple"
+            val result = combine (result, Seq.hash ty_0 t5)
+            val result = combine (result, Seq.hash Token.hash t6)
+          in
+            result
+          end
+         | Con {args = t7, id = t8} =>
+          let
+            val result = hashString "Con"
+            val result = combine (result, SyntaxSeq.hash ty_0 t7)
+            val result = combine (result, MaybeLongToken.hash t8)
+          in
+            result
+          end
+         | Arrow {from = t9, arrow = t10, to = t11} =>
+          let
+            val result = hashString "Arrow"
+            val result = combine (result, ty_0 t9)
+            val result = combine (result, Token.hash t10)
+            val result = combine (result, ty_0 t11)
+          in
+            result
+          end
+         | Parens {left = t12, ty = t13, right = t14} =>
+          let
+            val result = hashString "Parens"
+            val result = combine (result, Token.hash t12)
+            val result = combine (result, ty_0 t13)
+            val result = combine (result, Token.hash t14)
+          in
+            result
+          end
+      val ty = fn () => let val rec ty_0 = fn ? => ty ty_0 ? in ty_0 end
+    in val hash = ty ()
+    end
+    local
+      val rec ty = fn ty_0 =>
+        fn (Var t0, Var t1) => Token.== (t0, t1)
+         | ( Record {left = t2, elems = t3, delims = t4, right = t5}
+           , Record {left = t6, elems = t7, delims = t8, right = t9}
+           ) =>
+          Token.== (t2, t6)
+          andalso
+          Seq.==
+            (fn ( {lab = t0, colon = t1, ty = t2}
+                , {lab = t3, colon = t4, ty = t5}
+                ) =>
+               Token.== (t0, t3) andalso Token.== (t1, t4) andalso ty_0 (t2, t5))
+            (t3, t7) andalso Seq.== Token.== (t4, t8) andalso Token.== (t5, t9)
+         | ( Tuple {elems = t10, delims = t11}
+           , Tuple {elems = t12, delims = t13}
+           ) => Seq.== ty_0 (t10, t12) andalso Seq.== Token.== (t11, t13)
+         | (Con {args = t14, id = t15}, Con {args = t16, id = t17}) =>
+          SyntaxSeq.== ty_0 (t14, t16) andalso MaybeLongToken.== (t15, t17)
+         | ( Arrow {from = t18, arrow = t19, to = t20}
+           , Arrow {from = t21, arrow = t22, to = t23}
+           ) =>
+          ty_0 (t18, t21) andalso Token.== (t19, t22) andalso ty_0 (t20, t23)
+         | ( Parens {left = t24, ty = t25, right = t26}
+           , Parens {left = t27, ty = t28, right = t29}
+           ) =>
+          Token.== (t24, t27) andalso ty_0 (t25, t28)
+          andalso Token.== (t26, t29)
+         | _ => false
+      val ty = fn () => let val rec ty_0 = fn ? => ty ty_0 ? in ty_0 end
+    in val op== = ty ()
+    end
+  end
+end

--- a/Utils.sig
+++ b/Utils.sig
@@ -17,7 +17,7 @@ sig
   val syntaxSeqMapTy: ('a -> Ast.Ty.ty)
                       -> 'a Ast.SyntaxSeq.t
                       -> Ast.Ty.ty Ast.SyntaxSeq.t
-  val showTy: Ast.Ty.ty -> string
+  val normalize: Ast.Ty.ty -> Ast.Ty.ty
   val prettyTy: Ast.Ty.ty -> string
   val tySize: Ast.Ty.ty -> int
   val stripParens: Ast.Pat.pat -> Ast.Pat.pat

--- a/Utils.sml
+++ b/Utils.sml
@@ -68,8 +68,8 @@ struct
         SyntaxSeq.Many
           {left = left, elems = Seq.map f elems, delims = delims, right = right}
 
-  (* Converts a type into a normal form so it can be hashed. Things like duplicate
-     parenthesis are eliminated and all tokens are stripped.
+  (* Converts a type into a normal form so it can be hashed.
+     Parenthesis are eliminated and all tokens are stripped.
    *)
   fun normalize (Ty.Var tok) =
         Ty.Var (stripToken tok)
@@ -102,12 +102,7 @@ struct
     | normalize (Ty.Arrow {from, to, arrow}) =
         Ty.Arrow
           {from = normalize from, to = normalize to, arrow = stripToken arrow}
-    | normalize (Ty.Parens {ty as Ty.Parens _, ...}) = normalize ty
-    | normalize (Ty.Parens {ty as Ty.Tuple _, ...}) = normalize ty
-    | normalize (Ty.Parens {ty as Ty.Record _, ...}) = normalize ty
-    | normalize (Ty.Parens {ty, left, right}) =
-        Ty.Parens
-          {ty = normalize ty, left = stripToken left, right = stripToken right}
+    | normalize (Ty.Parens {ty, ...}) = normalize ty
 
   fun prettyTy ty =
     case ty of

--- a/build.sml
+++ b/build.sml
@@ -258,6 +258,7 @@ use "smlfmt/src/prettier-print/PrettierStrUtil.sml";
 use "smlfmt/src/prettier-print/PrettierStr.sml";
 use "smlfmt/src/prettier-print/PrettierFun.sml";
 use "smlfmt/src/prettier-print/PrettierPrintAst.sml";
+use "SmlfmtWrappers.sml";
 use "Fold.sml";
 use "FunctionalRecordUpdate.sml";
 use "Options.sml";

--- a/millet.toml
+++ b/millet.toml
@@ -4,3 +4,4 @@ root = "smlgen.mlb"
 [diagnostics]
 5043.severity = "ignore"
 4037.severity = "ignore"
+3007.severity = "ignore"

--- a/smlgen.cm
+++ b/smlgen.cm
@@ -8,6 +8,7 @@ Group is
   ./smlfmt/src/lex/sources.cm
   ./smlfmt/src/parse/sources.cm
   ./smlfmt/src/prettier-print/sources.cm
+  SmlfmtWrappers.sml
   Options.sml
   BuildAst.sig
   BuildAst.sml

--- a/smlgen.mlb
+++ b/smlgen.mlb
@@ -8,6 +8,7 @@ local
     ./smlfmt/src/parse/sources.mlb
     ./smlfmt/src/prettier-print/sources.mlb
   end
+  SmlfmtWrappers.sml
   Fold.sml
   FunctionalRecordUpdate.sml
   Options.sml

--- a/smlgen.mlkit.mlb
+++ b/smlgen.mlkit.mlb
@@ -60,6 +60,7 @@ smlfmt/src/prettier-print/PrettierStrUtil.sml
 smlfmt/src/prettier-print/PrettierStr.sml
 smlfmt/src/prettier-print/PrettierFun.sml
 smlfmt/src/prettier-print/PrettierPrintAst.sml
+SmlfmtWrappers.sml
 Fold.sml
 FunctionalRecordUpdate.sml
 Options.sml

--- a/smlgen.sml
+++ b/smlgen.sml
@@ -246,7 +246,6 @@ struct
         if String.size projGen > 0 then FilesGen.genProject projGen else ()
       val args = CommandLineArgs.positional ()
       val files = collectSMLFiles [] args
-      val files = if name = "not-smlnj" then files else List.tl files
     in
       case files of
         [] => ()
@@ -256,4 +255,4 @@ struct
     end
 end
 
-val main = fn () => ignore (Main.main ("not-smlnj", []))
+val main = fn () => ignore (Main.main ("", []))

--- a/smlgen.sml
+++ b/smlgen.sml
@@ -190,7 +190,7 @@ struct
       | _ => raise Fail "Just comments"
     end
 
-  fun main (name, _) =
+  fun main _ =
     let
       val opts as {maxSize, defaultTableSize, fileGen, projGen, ...} =
         { test = CommandLineArgs.parseFlag "test"

--- a/smlgen.sml
+++ b/smlgen.sml
@@ -154,6 +154,7 @@ struct
 
   fun doSML (opts: Options.opts) (filepath: string, args: string list) =
     let
+      val () = print ("Generating code for file: " ^ filepath ^ "\n")
       val args: args = List.map parseArg args
       val fp = FilePath.fromUnixPath filepath
       val hfp = FilePath.toHostPath
@@ -189,8 +190,7 @@ struct
       | _ => raise Fail "Just comments"
     end
 
-
-  fun main _ =
+  fun main (name, _) =
     let
       val opts as {maxSize, defaultTableSize, fileGen, projGen, ...} =
         { test = CommandLineArgs.parseFlag "test"
@@ -244,14 +244,16 @@ struct
         | _ => ()
       val () =
         if String.size projGen > 0 then FilesGen.genProject projGen else ()
+      val args = CommandLineArgs.positional ()
+      val files = collectSMLFiles [] args
+      val files = if name = "not-smlnj" then files else List.tl files
     in
-      case CommandLineArgs.positional () of
+      case files of
         [] => ()
-      | args =>
-          List.app (fn file :: args => doSML opts (file, args) | _ => ())
-            (collectSMLFiles [] args);
+      | _ =>
+          List.app (fn file :: args => doSML opts (file, args) | _ => ()) files;
       OS.Process.success
     end
 end
 
-val main = fn () => ignore (Main.main ("", []))
+val main = fn () => ignore (Main.main ("not-smlnj", []))

--- a/test/test12.sml.expected
+++ b/test/test12.sml.expected
@@ -12,19 +12,19 @@ val expr_stmt = fn (d_, c_, b_) =>
     open Tie
     val Y = Generic.Y
     val
-      _ & _ & _ & _ & _ & _ & expr_0 & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ &
-        _ & _ & _ & stmt_19 & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ &
-        _ =
+      _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & stmt_19 & _ & _ & _ &
+        expr_0 & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ &
+        _ & _ =
       fix
         (Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y
          *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y
          *` Y *` Y *` Y *` Y *` Y *` Y *` Y)
-        (fn expr_27 & stmt_29 & expr_11 & expr_4 & expr_21 & expr_22 & expr_0 &
-             stmt_16 & expr_33 & expr_30 & stmt_8 & expr_9 & expr_13 & expr_24 &
-             expr_32 & stmt_14 & expr_35 & expr_28 & expr_17 & expr_23 & expr_20 &
-             stmt_19 & expr_5 & stmt_6 & expr_31 & expr_2 & expr_15 & expr_18 &
-             stmt_3 & expr_7 & stmt_1 & expr_12 & expr_10 & expr_25 & stmt_26 &
-             expr_34 =>
+        (fn stmt_26 & stmt_16 & stmt_14 & expr_34 & expr_4 & expr_15 & expr_22 &
+             expr_31 & expr_5 & expr_12 & expr_13 & expr_7 & stmt_6 & stmt_19 &
+             stmt_8 & expr_30 & expr_33 & expr_0 & expr_24 & expr_23 & expr_20 &
+             expr_2 & expr_25 & expr_10 & expr_11 & expr_21 & expr_32 & expr_9 &
+             expr_27 & expr_35 & stmt_3 & stmt_29 & stmt_1 & expr_28 & expr_17 &
+             expr_18 =>
            let
              open Generic
              fun expr (expr_35, expr_13, stmt_1, b_, c_, d_) =
@@ -46,42 +46,42 @@ val expr_stmt = fn (d_, c_, b_) =>
                  , fn INR ? => If ? | INL ? => Assign ?
                  )
            in
-             expr (expr_33, expr_28, stmt_16, c_, b_, c_)
-             & stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_)
-             & expr (expr_10, expr_11, stmt_6, d_, d_, b_)
-             & expr (expr_4, expr_4, stmt_3, b_, b_, b_)
-             & expr (expr_20, expr_20, stmt_14, c_, d_, d_)
-             & expr (expr_21, expr_22, stmt_19, d_, d_, c_)
-             & expr (expr_35, expr_13, stmt_1, b_, c_, d_)
+             stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_)
              & stmt (stmt_16, stmt_16, expr_17, expr_17, c_, c_)
-             & expr (expr_28, expr_33, stmt_26, c_, c_, b_)
-             & expr (expr_32, expr_31, stmt_3, b_, c_, b_)
-             & stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_)
-             & expr (expr_9, expr_9, stmt_8, d_, d_, d_)
-             & expr (expr_24, expr_0, stmt_14, c_, b_, d_)
-             & expr (expr_34, expr_25, stmt_6, d_, c_, b_)
-             & expr (expr_31, expr_32, stmt_29, b_, b_, c_)
              & stmt (stmt_14, stmt_19, expr_22, expr_15, d_, c_)
-             & expr (expr_25, expr_34, stmt_19, d_, b_, c_)
-             & expr (expr_27, expr_27, stmt_29, b_, c_, c_)
-             & expr (expr_17, expr_17, stmt_16, c_, c_, c_)
+             & expr (expr_13, expr_35, stmt_29, b_, d_, c_)
+             & expr (expr_4, expr_4, stmt_3, b_, b_, b_)
+             & expr (expr_23, expr_18, stmt_16, c_, d_, c_)
+             & expr (expr_21, expr_22, stmt_19, d_, d_, c_)
+             & expr (expr_30, expr_30, stmt_26, c_, b_, b_)
+             & expr (expr_2, expr_2, stmt_6, d_, b_, b_)
+             & expr (expr_5, expr_12, stmt_1, b_, b_, d_)
+             & expr (expr_24, expr_0, stmt_14, c_, b_, d_)
+             & expr (expr_11, expr_10, stmt_8, d_, b_, d_)
+             & stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_)
+             & stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_)
+             & stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_)
+             & expr (expr_32, expr_31, stmt_3, b_, c_, b_)
+             & expr (expr_28, expr_33, stmt_26, c_, c_, b_)
+             & expr (expr_35, expr_13, stmt_1, b_, c_, d_)
+             & expr (expr_34, expr_25, stmt_6, d_, c_, b_)
              & expr (expr_18, expr_23, stmt_14, c_, c_, d_)
              & expr (expr_22, expr_21, stmt_8, d_, c_, d_)
-             & stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_)
-             & expr (expr_2, expr_2, stmt_6, d_, b_, b_)
-             & stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_)
-             & expr (expr_30, expr_30, stmt_26, c_, b_, b_)
              & expr (expr_12, expr_5, stmt_3, b_, d_, b_)
-             & expr (expr_23, expr_18, stmt_16, c_, d_, c_)
-             & expr (expr_15, expr_15, stmt_19, d_, c_, c_)
-             & stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_)
-             & expr (expr_11, expr_10, stmt_8, d_, b_, d_)
-             & stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_)
-             & expr (expr_5, expr_12, stmt_1, b_, b_, d_)
-             & expr (expr_7, expr_7, stmt_1, b_, d_, d_)
              & expr (expr_0, expr_24, stmt_26, c_, d_, b_)
-             & stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_)
-             & expr (expr_13, expr_35, stmt_29, b_, d_, c_)
+             & expr (expr_7, expr_7, stmt_1, b_, d_, d_)
+             & expr (expr_10, expr_11, stmt_6, d_, d_, b_)
+             & expr (expr_20, expr_20, stmt_14, c_, d_, d_)
+             & expr (expr_31, expr_32, stmt_29, b_, b_, c_)
+             & expr (expr_9, expr_9, stmt_8, d_, d_, d_)
+             & expr (expr_33, expr_28, stmt_16, c_, b_, c_)
+             & expr (expr_25, expr_34, stmt_19, d_, b_, c_)
+             & stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_)
+             & stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_)
+             & stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_)
+             & expr (expr_27, expr_27, stmt_29, b_, c_, c_)
+             & expr (expr_17, expr_17, stmt_16, c_, c_, c_)
+             & expr (expr_15, expr_15, stmt_19, d_, c_, c_)
            end)
   in
     (expr_0, stmt_19)
@@ -110,42 +110,43 @@ local
         ] ^ ")"
   val expr_stmt = fn (d_, c_, b_) =>
     let
-      val rec expr_27 = fn ? => expr (expr_33, expr_28, stmt_16, c_, b_, c_) ?
-      and stmt_29 = fn ? => stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_) ?
-      and expr_11 = fn ? => expr (expr_10, expr_11, stmt_6, d_, d_, b_) ?
-      and expr_4 = fn ? => expr (expr_4, expr_4, stmt_3, b_, b_, b_) ?
-      and expr_21 = fn ? => expr (expr_20, expr_20, stmt_14, c_, d_, d_) ?
-      and expr_22 = fn ? => expr (expr_21, expr_22, stmt_19, d_, d_, c_) ?
-      and expr_0 = fn ? => expr (expr_35, expr_13, stmt_1, b_, c_, d_) ?
+      val rec stmt_26 = fn ? =>
+        stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_) ?
       and stmt_16 = fn ? => stmt (stmt_16, stmt_16, expr_17, expr_17, c_, c_) ?
-      and expr_33 = fn ? => expr (expr_28, expr_33, stmt_26, c_, c_, b_) ?
-      and expr_30 = fn ? => expr (expr_32, expr_31, stmt_3, b_, c_, b_) ?
-      and stmt_8 = fn ? => stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_) ?
-      and expr_9 = fn ? => expr (expr_9, expr_9, stmt_8, d_, d_, d_) ?
-      and expr_13 = fn ? => expr (expr_24, expr_0, stmt_14, c_, b_, d_) ?
-      and expr_24 = fn ? => expr (expr_34, expr_25, stmt_6, d_, c_, b_) ?
-      and expr_32 = fn ? => expr (expr_31, expr_32, stmt_29, b_, b_, c_) ?
       and stmt_14 = fn ? => stmt (stmt_14, stmt_19, expr_22, expr_15, d_, c_) ?
-      and expr_35 = fn ? => expr (expr_25, expr_34, stmt_19, d_, b_, c_) ?
-      and expr_28 = fn ? => expr (expr_27, expr_27, stmt_29, b_, c_, c_) ?
-      and expr_17 = fn ? => expr (expr_17, expr_17, stmt_16, c_, c_, c_) ?
+      and expr_34 = fn ? => expr (expr_13, expr_35, stmt_29, b_, d_, c_) ?
+      and expr_4 = fn ? => expr (expr_4, expr_4, stmt_3, b_, b_, b_) ?
+      and expr_15 = fn ? => expr (expr_23, expr_18, stmt_16, c_, d_, c_) ?
+      and expr_22 = fn ? => expr (expr_21, expr_22, stmt_19, d_, d_, c_) ?
+      and expr_31 = fn ? => expr (expr_30, expr_30, stmt_26, c_, b_, b_) ?
+      and expr_5 = fn ? => expr (expr_2, expr_2, stmt_6, d_, b_, b_) ?
+      and expr_12 = fn ? => expr (expr_5, expr_12, stmt_1, b_, b_, d_) ?
+      and expr_13 = fn ? => expr (expr_24, expr_0, stmt_14, c_, b_, d_) ?
+      and expr_7 = fn ? => expr (expr_11, expr_10, stmt_8, d_, b_, d_) ?
+      and stmt_6 = fn ? => stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_) ?
+      and stmt_19 = fn ? => stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_) ?
+      and stmt_8 = fn ? => stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_) ?
+      and expr_30 = fn ? => expr (expr_32, expr_31, stmt_3, b_, c_, b_) ?
+      and expr_33 = fn ? => expr (expr_28, expr_33, stmt_26, c_, c_, b_) ?
+      and expr_0 = fn ? => expr (expr_35, expr_13, stmt_1, b_, c_, d_) ?
+      and expr_24 = fn ? => expr (expr_34, expr_25, stmt_6, d_, c_, b_) ?
       and expr_23 = fn ? => expr (expr_18, expr_23, stmt_14, c_, c_, d_) ?
       and expr_20 = fn ? => expr (expr_22, expr_21, stmt_8, d_, c_, d_) ?
-      and stmt_19 = fn ? => stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_) ?
-      and expr_5 = fn ? => expr (expr_2, expr_2, stmt_6, d_, b_, b_) ?
-      and stmt_6 = fn ? => stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_) ?
-      and expr_31 = fn ? => expr (expr_30, expr_30, stmt_26, c_, b_, b_) ?
       and expr_2 = fn ? => expr (expr_12, expr_5, stmt_3, b_, d_, b_) ?
-      and expr_15 = fn ? => expr (expr_23, expr_18, stmt_16, c_, d_, c_) ?
-      and expr_18 = fn ? => expr (expr_15, expr_15, stmt_19, d_, c_, c_) ?
-      and stmt_3 = fn ? => stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_) ?
-      and expr_7 = fn ? => expr (expr_11, expr_10, stmt_8, d_, b_, d_) ?
-      and stmt_1 = fn ? => stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_) ?
-      and expr_12 = fn ? => expr (expr_5, expr_12, stmt_1, b_, b_, d_) ?
-      and expr_10 = fn ? => expr (expr_7, expr_7, stmt_1, b_, d_, d_) ?
       and expr_25 = fn ? => expr (expr_0, expr_24, stmt_26, c_, d_, b_) ?
-      and stmt_26 = fn ? => stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_) ?
-      and expr_34 = fn ? => expr (expr_13, expr_35, stmt_29, b_, d_, c_) ?
+      and expr_10 = fn ? => expr (expr_7, expr_7, stmt_1, b_, d_, d_) ?
+      and expr_11 = fn ? => expr (expr_10, expr_11, stmt_6, d_, d_, b_) ?
+      and expr_21 = fn ? => expr (expr_20, expr_20, stmt_14, c_, d_, d_) ?
+      and expr_32 = fn ? => expr (expr_31, expr_32, stmt_29, b_, b_, c_) ?
+      and expr_9 = fn ? => expr (expr_9, expr_9, stmt_8, d_, d_, d_) ?
+      and expr_27 = fn ? => expr (expr_33, expr_28, stmt_16, c_, b_, c_) ?
+      and expr_35 = fn ? => expr (expr_25, expr_34, stmt_19, d_, b_, c_) ?
+      and stmt_3 = fn ? => stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_) ?
+      and stmt_29 = fn ? => stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_) ?
+      and stmt_1 = fn ? => stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_) ?
+      and expr_28 = fn ? => expr (expr_27, expr_27, stmt_29, b_, c_, c_) ?
+      and expr_17 = fn ? => expr (expr_17, expr_17, stmt_16, c_, c_, c_) ?
+      and expr_18 = fn ? => expr (expr_15, expr_15, stmt_19, d_, c_, c_) ?
     in
       (expr_0, stmt_19)
     end
@@ -193,42 +194,43 @@ local
        | ? => ?)
   val expr_stmt = fn (d_, c_, b_) =>
     let
-      val rec expr_27 = fn ? => expr (expr_33, expr_28, stmt_16, c_, b_, c_) ?
-      and stmt_29 = fn ? => stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_) ?
-      and expr_11 = fn ? => expr (expr_10, expr_11, stmt_6, d_, d_, b_) ?
-      and expr_4 = fn ? => expr (expr_4, expr_4, stmt_3, b_, b_, b_) ?
-      and expr_21 = fn ? => expr (expr_20, expr_20, stmt_14, c_, d_, d_) ?
-      and expr_22 = fn ? => expr (expr_21, expr_22, stmt_19, d_, d_, c_) ?
-      and expr_0 = fn ? => expr (expr_35, expr_13, stmt_1, b_, c_, d_) ?
+      val rec stmt_26 = fn ? =>
+        stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_) ?
       and stmt_16 = fn ? => stmt (stmt_16, stmt_16, expr_17, expr_17, c_, c_) ?
-      and expr_33 = fn ? => expr (expr_28, expr_33, stmt_26, c_, c_, b_) ?
-      and expr_30 = fn ? => expr (expr_32, expr_31, stmt_3, b_, c_, b_) ?
-      and stmt_8 = fn ? => stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_) ?
-      and expr_9 = fn ? => expr (expr_9, expr_9, stmt_8, d_, d_, d_) ?
-      and expr_13 = fn ? => expr (expr_24, expr_0, stmt_14, c_, b_, d_) ?
-      and expr_24 = fn ? => expr (expr_34, expr_25, stmt_6, d_, c_, b_) ?
-      and expr_32 = fn ? => expr (expr_31, expr_32, stmt_29, b_, b_, c_) ?
       and stmt_14 = fn ? => stmt (stmt_14, stmt_19, expr_22, expr_15, d_, c_) ?
-      and expr_35 = fn ? => expr (expr_25, expr_34, stmt_19, d_, b_, c_) ?
-      and expr_28 = fn ? => expr (expr_27, expr_27, stmt_29, b_, c_, c_) ?
-      and expr_17 = fn ? => expr (expr_17, expr_17, stmt_16, c_, c_, c_) ?
+      and expr_34 = fn ? => expr (expr_13, expr_35, stmt_29, b_, d_, c_) ?
+      and expr_4 = fn ? => expr (expr_4, expr_4, stmt_3, b_, b_, b_) ?
+      and expr_15 = fn ? => expr (expr_23, expr_18, stmt_16, c_, d_, c_) ?
+      and expr_22 = fn ? => expr (expr_21, expr_22, stmt_19, d_, d_, c_) ?
+      and expr_31 = fn ? => expr (expr_30, expr_30, stmt_26, c_, b_, b_) ?
+      and expr_5 = fn ? => expr (expr_2, expr_2, stmt_6, d_, b_, b_) ?
+      and expr_12 = fn ? => expr (expr_5, expr_12, stmt_1, b_, b_, d_) ?
+      and expr_13 = fn ? => expr (expr_24, expr_0, stmt_14, c_, b_, d_) ?
+      and expr_7 = fn ? => expr (expr_11, expr_10, stmt_8, d_, b_, d_) ?
+      and stmt_6 = fn ? => stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_) ?
+      and stmt_19 = fn ? => stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_) ?
+      and stmt_8 = fn ? => stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_) ?
+      and expr_30 = fn ? => expr (expr_32, expr_31, stmt_3, b_, c_, b_) ?
+      and expr_33 = fn ? => expr (expr_28, expr_33, stmt_26, c_, c_, b_) ?
+      and expr_0 = fn ? => expr (expr_35, expr_13, stmt_1, b_, c_, d_) ?
+      and expr_24 = fn ? => expr (expr_34, expr_25, stmt_6, d_, c_, b_) ?
       and expr_23 = fn ? => expr (expr_18, expr_23, stmt_14, c_, c_, d_) ?
       and expr_20 = fn ? => expr (expr_22, expr_21, stmt_8, d_, c_, d_) ?
-      and stmt_19 = fn ? => stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_) ?
-      and expr_5 = fn ? => expr (expr_2, expr_2, stmt_6, d_, b_, b_) ?
-      and stmt_6 = fn ? => stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_) ?
-      and expr_31 = fn ? => expr (expr_30, expr_30, stmt_26, c_, b_, b_) ?
       and expr_2 = fn ? => expr (expr_12, expr_5, stmt_3, b_, d_, b_) ?
-      and expr_15 = fn ? => expr (expr_23, expr_18, stmt_16, c_, d_, c_) ?
-      and expr_18 = fn ? => expr (expr_15, expr_15, stmt_19, d_, c_, c_) ?
-      and stmt_3 = fn ? => stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_) ?
-      and expr_7 = fn ? => expr (expr_11, expr_10, stmt_8, d_, b_, d_) ?
-      and stmt_1 = fn ? => stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_) ?
-      and expr_12 = fn ? => expr (expr_5, expr_12, stmt_1, b_, b_, d_) ?
-      and expr_10 = fn ? => expr (expr_7, expr_7, stmt_1, b_, d_, d_) ?
       and expr_25 = fn ? => expr (expr_0, expr_24, stmt_26, c_, d_, b_) ?
-      and stmt_26 = fn ? => stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_) ?
-      and expr_34 = fn ? => expr (expr_13, expr_35, stmt_29, b_, d_, c_) ?
+      and expr_10 = fn ? => expr (expr_7, expr_7, stmt_1, b_, d_, d_) ?
+      and expr_11 = fn ? => expr (expr_10, expr_11, stmt_6, d_, d_, b_) ?
+      and expr_21 = fn ? => expr (expr_20, expr_20, stmt_14, c_, d_, d_) ?
+      and expr_32 = fn ? => expr (expr_31, expr_32, stmt_29, b_, b_, c_) ?
+      and expr_9 = fn ? => expr (expr_9, expr_9, stmt_8, d_, d_, d_) ?
+      and expr_27 = fn ? => expr (expr_33, expr_28, stmt_16, c_, b_, c_) ?
+      and expr_35 = fn ? => expr (expr_25, expr_34, stmt_19, d_, b_, c_) ?
+      and stmt_3 = fn ? => stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_) ?
+      and stmt_29 = fn ? => stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_) ?
+      and stmt_1 = fn ? => stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_) ?
+      and expr_28 = fn ? => expr (expr_27, expr_27, stmt_29, b_, c_, c_) ?
+      and expr_17 = fn ? => expr (expr_17, expr_17, stmt_16, c_, c_, c_) ?
+      and expr_18 = fn ? => expr (expr_15, expr_15, stmt_19, d_, c_, c_) ?
     in
       (expr_0, stmt_19)
     end
@@ -255,42 +257,43 @@ local
      | _ => false
   val expr_stmt = fn (d_, c_, b_) =>
     let
-      val rec expr_27 = fn ? => expr (expr_33, expr_28, stmt_16, c_, b_, c_) ?
-      and stmt_29 = fn ? => stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_) ?
-      and expr_11 = fn ? => expr (expr_10, expr_11, stmt_6, d_, d_, b_) ?
-      and expr_4 = fn ? => expr (expr_4, expr_4, stmt_3, b_, b_, b_) ?
-      and expr_21 = fn ? => expr (expr_20, expr_20, stmt_14, c_, d_, d_) ?
-      and expr_22 = fn ? => expr (expr_21, expr_22, stmt_19, d_, d_, c_) ?
-      and expr_0 = fn ? => expr (expr_35, expr_13, stmt_1, b_, c_, d_) ?
+      val rec stmt_26 = fn ? =>
+        stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_) ?
       and stmt_16 = fn ? => stmt (stmt_16, stmt_16, expr_17, expr_17, c_, c_) ?
-      and expr_33 = fn ? => expr (expr_28, expr_33, stmt_26, c_, c_, b_) ?
-      and expr_30 = fn ? => expr (expr_32, expr_31, stmt_3, b_, c_, b_) ?
-      and stmt_8 = fn ? => stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_) ?
-      and expr_9 = fn ? => expr (expr_9, expr_9, stmt_8, d_, d_, d_) ?
-      and expr_13 = fn ? => expr (expr_24, expr_0, stmt_14, c_, b_, d_) ?
-      and expr_24 = fn ? => expr (expr_34, expr_25, stmt_6, d_, c_, b_) ?
-      and expr_32 = fn ? => expr (expr_31, expr_32, stmt_29, b_, b_, c_) ?
       and stmt_14 = fn ? => stmt (stmt_14, stmt_19, expr_22, expr_15, d_, c_) ?
-      and expr_35 = fn ? => expr (expr_25, expr_34, stmt_19, d_, b_, c_) ?
-      and expr_28 = fn ? => expr (expr_27, expr_27, stmt_29, b_, c_, c_) ?
-      and expr_17 = fn ? => expr (expr_17, expr_17, stmt_16, c_, c_, c_) ?
+      and expr_34 = fn ? => expr (expr_13, expr_35, stmt_29, b_, d_, c_) ?
+      and expr_4 = fn ? => expr (expr_4, expr_4, stmt_3, b_, b_, b_) ?
+      and expr_15 = fn ? => expr (expr_23, expr_18, stmt_16, c_, d_, c_) ?
+      and expr_22 = fn ? => expr (expr_21, expr_22, stmt_19, d_, d_, c_) ?
+      and expr_31 = fn ? => expr (expr_30, expr_30, stmt_26, c_, b_, b_) ?
+      and expr_5 = fn ? => expr (expr_2, expr_2, stmt_6, d_, b_, b_) ?
+      and expr_12 = fn ? => expr (expr_5, expr_12, stmt_1, b_, b_, d_) ?
+      and expr_13 = fn ? => expr (expr_24, expr_0, stmt_14, c_, b_, d_) ?
+      and expr_7 = fn ? => expr (expr_11, expr_10, stmt_8, d_, b_, d_) ?
+      and stmt_6 = fn ? => stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_) ?
+      and stmt_19 = fn ? => stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_) ?
+      and stmt_8 = fn ? => stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_) ?
+      and expr_30 = fn ? => expr (expr_32, expr_31, stmt_3, b_, c_, b_) ?
+      and expr_33 = fn ? => expr (expr_28, expr_33, stmt_26, c_, c_, b_) ?
+      and expr_0 = fn ? => expr (expr_35, expr_13, stmt_1, b_, c_, d_) ?
+      and expr_24 = fn ? => expr (expr_34, expr_25, stmt_6, d_, c_, b_) ?
       and expr_23 = fn ? => expr (expr_18, expr_23, stmt_14, c_, c_, d_) ?
       and expr_20 = fn ? => expr (expr_22, expr_21, stmt_8, d_, c_, d_) ?
-      and stmt_19 = fn ? => stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_) ?
-      and expr_5 = fn ? => expr (expr_2, expr_2, stmt_6, d_, b_, b_) ?
-      and stmt_6 = fn ? => stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_) ?
-      and expr_31 = fn ? => expr (expr_30, expr_30, stmt_26, c_, b_, b_) ?
       and expr_2 = fn ? => expr (expr_12, expr_5, stmt_3, b_, d_, b_) ?
-      and expr_15 = fn ? => expr (expr_23, expr_18, stmt_16, c_, d_, c_) ?
-      and expr_18 = fn ? => expr (expr_15, expr_15, stmt_19, d_, c_, c_) ?
-      and stmt_3 = fn ? => stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_) ?
-      and expr_7 = fn ? => expr (expr_11, expr_10, stmt_8, d_, b_, d_) ?
-      and stmt_1 = fn ? => stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_) ?
-      and expr_12 = fn ? => expr (expr_5, expr_12, stmt_1, b_, b_, d_) ?
-      and expr_10 = fn ? => expr (expr_7, expr_7, stmt_1, b_, d_, d_) ?
       and expr_25 = fn ? => expr (expr_0, expr_24, stmt_26, c_, d_, b_) ?
-      and stmt_26 = fn ? => stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_) ?
-      and expr_34 = fn ? => expr (expr_13, expr_35, stmt_29, b_, d_, c_) ?
+      and expr_10 = fn ? => expr (expr_7, expr_7, stmt_1, b_, d_, d_) ?
+      and expr_11 = fn ? => expr (expr_10, expr_11, stmt_6, d_, d_, b_) ?
+      and expr_21 = fn ? => expr (expr_20, expr_20, stmt_14, c_, d_, d_) ?
+      and expr_32 = fn ? => expr (expr_31, expr_32, stmt_29, b_, b_, c_) ?
+      and expr_9 = fn ? => expr (expr_9, expr_9, stmt_8, d_, d_, d_) ?
+      and expr_27 = fn ? => expr (expr_33, expr_28, stmt_16, c_, b_, c_) ?
+      and expr_35 = fn ? => expr (expr_25, expr_34, stmt_19, d_, b_, c_) ?
+      and stmt_3 = fn ? => stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_) ?
+      and stmt_29 = fn ? => stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_) ?
+      and stmt_1 = fn ? => stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_) ?
+      and expr_28 = fn ? => expr (expr_27, expr_27, stmt_29, b_, c_, c_) ?
+      and expr_17 = fn ? => expr (expr_17, expr_17, stmt_16, c_, c_, c_) ?
+      and expr_18 = fn ? => expr (expr_15, expr_15, stmt_19, d_, c_, c_) ?
     in
       (expr_0, stmt_19)
     end
@@ -350,42 +353,43 @@ local
       end
   val expr_stmt = fn (d_, c_, b_) =>
     let
-      val rec expr_27 = fn ? => expr (expr_33, expr_28, stmt_16, c_, b_, c_) ?
-      and stmt_29 = fn ? => stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_) ?
-      and expr_11 = fn ? => expr (expr_10, expr_11, stmt_6, d_, d_, b_) ?
-      and expr_4 = fn ? => expr (expr_4, expr_4, stmt_3, b_, b_, b_) ?
-      and expr_21 = fn ? => expr (expr_20, expr_20, stmt_14, c_, d_, d_) ?
-      and expr_22 = fn ? => expr (expr_21, expr_22, stmt_19, d_, d_, c_) ?
-      and expr_0 = fn ? => expr (expr_35, expr_13, stmt_1, b_, c_, d_) ?
+      val rec stmt_26 = fn ? =>
+        stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_) ?
       and stmt_16 = fn ? => stmt (stmt_16, stmt_16, expr_17, expr_17, c_, c_) ?
-      and expr_33 = fn ? => expr (expr_28, expr_33, stmt_26, c_, c_, b_) ?
-      and expr_30 = fn ? => expr (expr_32, expr_31, stmt_3, b_, c_, b_) ?
-      and stmt_8 = fn ? => stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_) ?
-      and expr_9 = fn ? => expr (expr_9, expr_9, stmt_8, d_, d_, d_) ?
-      and expr_13 = fn ? => expr (expr_24, expr_0, stmt_14, c_, b_, d_) ?
-      and expr_24 = fn ? => expr (expr_34, expr_25, stmt_6, d_, c_, b_) ?
-      and expr_32 = fn ? => expr (expr_31, expr_32, stmt_29, b_, b_, c_) ?
       and stmt_14 = fn ? => stmt (stmt_14, stmt_19, expr_22, expr_15, d_, c_) ?
-      and expr_35 = fn ? => expr (expr_25, expr_34, stmt_19, d_, b_, c_) ?
-      and expr_28 = fn ? => expr (expr_27, expr_27, stmt_29, b_, c_, c_) ?
-      and expr_17 = fn ? => expr (expr_17, expr_17, stmt_16, c_, c_, c_) ?
+      and expr_34 = fn ? => expr (expr_13, expr_35, stmt_29, b_, d_, c_) ?
+      and expr_4 = fn ? => expr (expr_4, expr_4, stmt_3, b_, b_, b_) ?
+      and expr_15 = fn ? => expr (expr_23, expr_18, stmt_16, c_, d_, c_) ?
+      and expr_22 = fn ? => expr (expr_21, expr_22, stmt_19, d_, d_, c_) ?
+      and expr_31 = fn ? => expr (expr_30, expr_30, stmt_26, c_, b_, b_) ?
+      and expr_5 = fn ? => expr (expr_2, expr_2, stmt_6, d_, b_, b_) ?
+      and expr_12 = fn ? => expr (expr_5, expr_12, stmt_1, b_, b_, d_) ?
+      and expr_13 = fn ? => expr (expr_24, expr_0, stmt_14, c_, b_, d_) ?
+      and expr_7 = fn ? => expr (expr_11, expr_10, stmt_8, d_, b_, d_) ?
+      and stmt_6 = fn ? => stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_) ?
+      and stmt_19 = fn ? => stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_) ?
+      and stmt_8 = fn ? => stmt (stmt_8, stmt_8, expr_9, expr_9, d_, d_) ?
+      and expr_30 = fn ? => expr (expr_32, expr_31, stmt_3, b_, c_, b_) ?
+      and expr_33 = fn ? => expr (expr_28, expr_33, stmt_26, c_, c_, b_) ?
+      and expr_0 = fn ? => expr (expr_35, expr_13, stmt_1, b_, c_, d_) ?
+      and expr_24 = fn ? => expr (expr_34, expr_25, stmt_6, d_, c_, b_) ?
       and expr_23 = fn ? => expr (expr_18, expr_23, stmt_14, c_, c_, d_) ?
       and expr_20 = fn ? => expr (expr_22, expr_21, stmt_8, d_, c_, d_) ?
-      and stmt_19 = fn ? => stmt (stmt_19, stmt_14, expr_23, expr_20, c_, d_) ?
-      and expr_5 = fn ? => expr (expr_2, expr_2, stmt_6, d_, b_, b_) ?
-      and stmt_6 = fn ? => stmt (stmt_6, stmt_1, expr_12, expr_7, b_, d_) ?
-      and expr_31 = fn ? => expr (expr_30, expr_30, stmt_26, c_, b_, b_) ?
       and expr_2 = fn ? => expr (expr_12, expr_5, stmt_3, b_, d_, b_) ?
-      and expr_15 = fn ? => expr (expr_23, expr_18, stmt_16, c_, d_, c_) ?
-      and expr_18 = fn ? => expr (expr_15, expr_15, stmt_19, d_, c_, c_) ?
-      and stmt_3 = fn ? => stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_) ?
-      and expr_7 = fn ? => expr (expr_11, expr_10, stmt_8, d_, b_, d_) ?
-      and stmt_1 = fn ? => stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_) ?
-      and expr_12 = fn ? => expr (expr_5, expr_12, stmt_1, b_, b_, d_) ?
-      and expr_10 = fn ? => expr (expr_7, expr_7, stmt_1, b_, d_, d_) ?
       and expr_25 = fn ? => expr (expr_0, expr_24, stmt_26, c_, d_, b_) ?
-      and stmt_26 = fn ? => stmt (stmt_26, stmt_29, expr_32, expr_27, b_, c_) ?
-      and expr_34 = fn ? => expr (expr_13, expr_35, stmt_29, b_, d_, c_) ?
+      and expr_10 = fn ? => expr (expr_7, expr_7, stmt_1, b_, d_, d_) ?
+      and expr_11 = fn ? => expr (expr_10, expr_11, stmt_6, d_, d_, b_) ?
+      and expr_21 = fn ? => expr (expr_20, expr_20, stmt_14, c_, d_, d_) ?
+      and expr_32 = fn ? => expr (expr_31, expr_32, stmt_29, b_, b_, c_) ?
+      and expr_9 = fn ? => expr (expr_9, expr_9, stmt_8, d_, d_, d_) ?
+      and expr_27 = fn ? => expr (expr_33, expr_28, stmt_16, c_, b_, c_) ?
+      and expr_35 = fn ? => expr (expr_25, expr_34, stmt_19, d_, b_, c_) ?
+      and stmt_3 = fn ? => stmt (stmt_3, stmt_3, expr_4, expr_4, b_, b_) ?
+      and stmt_29 = fn ? => stmt (stmt_29, stmt_26, expr_33, expr_30, c_, b_) ?
+      and stmt_1 = fn ? => stmt (stmt_1, stmt_6, expr_11, expr_2, d_, b_) ?
+      and expr_28 = fn ? => expr (expr_27, expr_27, stmt_29, b_, c_, c_) ?
+      and expr_17 = fn ? => expr (expr_17, expr_17, stmt_16, c_, c_, c_) ?
+      and expr_18 = fn ? => expr (expr_15, expr_15, stmt_19, d_, c_, c_) ?
     in
       (expr_0, stmt_19)
     end
@@ -409,10 +413,10 @@ val expr_stmt = fn (c_, d_, b_) =>
   let
     open Tie
     val Y = Generic.Y
-    val _ & _ & _ & _ & _ & _ & _ & stmt_8 & _ & _ & expr_0 & _ =
+    val expr_0 & _ & stmt_8 & _ & _ & _ & _ & _ & _ & _ & _ & _ =
       fix (Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y)
-        (fn stmt_3 & expr_11 & stmt_10 & expr_4 & expr_2 & expr_9 & stmt_1 &
-             stmt_8 & stmt_6 & stmt_5 & expr_0 & expr_7 =>
+        (fn expr_0 & expr_4 & stmt_8 & stmt_10 & expr_2 & expr_11 & stmt_3 &
+             stmt_6 & expr_7 & expr_9 & stmt_1 & stmt_5 =>
            let
              open Generic
              fun expr (expr_9, expr_4, stmt_1, b_, d_, c_) =
@@ -434,18 +438,18 @@ val expr_stmt = fn (c_, d_, b_) =>
                  , fn INR ? => If ? | INL ? => Assign ?
                  )
            in
-             stmt (stmt_8, expr_2, expr_4, b_, c_, d_)
-             & expr (expr_4, expr_9, stmt_6, b_, c_, d_)
-             & stmt (stmt_1, expr_9, expr_11, c_, b_, d_)
+             expr (expr_9, expr_4, stmt_1, b_, d_, c_)
              & expr (expr_11, expr_2, stmt_5, c_, b_, d_)
+             & stmt (stmt_3, expr_7, expr_9, b_, d_, c_)
+             & stmt (stmt_1, expr_9, expr_11, c_, b_, d_)
              & expr (expr_7, expr_0, stmt_3, d_, c_, b_)
+             & expr (expr_4, expr_9, stmt_6, b_, c_, d_)
+             & stmt (stmt_8, expr_2, expr_4, b_, c_, d_)
+             & stmt (stmt_5, expr_11, expr_7, d_, c_, b_)
+             & expr (expr_2, expr_11, stmt_8, c_, d_, b_)
              & expr (expr_0, expr_7, stmt_10, d_, b_, c_)
              & stmt (stmt_10, expr_0, expr_2, c_, d_, b_)
-             & stmt (stmt_3, expr_7, expr_9, b_, d_, c_)
-             & stmt (stmt_5, expr_11, expr_7, d_, c_, b_)
              & stmt (stmt_6, expr_4, expr_0, d_, b_, c_)
-             & expr (expr_9, expr_4, stmt_1, b_, d_, c_)
-             & expr (expr_2, expr_11, stmt_8, c_, d_, b_)
            end)
   in
     (expr_0, stmt_8)
@@ -474,18 +478,18 @@ local
         ] ^ ")"
   val expr_stmt = fn (c_, d_, b_) =>
     let
-      val rec stmt_3 = fn ? => stmt (stmt_8, expr_2, expr_4, b_, c_, d_) ?
-      and expr_11 = fn ? => expr (expr_4, expr_9, stmt_6, b_, c_, d_) ?
-      and stmt_10 = fn ? => stmt (stmt_1, expr_9, expr_11, c_, b_, d_) ?
+      val rec expr_0 = fn ? => expr (expr_9, expr_4, stmt_1, b_, d_, c_) ?
       and expr_4 = fn ? => expr (expr_11, expr_2, stmt_5, c_, b_, d_) ?
+      and stmt_8 = fn ? => stmt (stmt_3, expr_7, expr_9, b_, d_, c_) ?
+      and stmt_10 = fn ? => stmt (stmt_1, expr_9, expr_11, c_, b_, d_) ?
       and expr_2 = fn ? => expr (expr_7, expr_0, stmt_3, d_, c_, b_) ?
+      and expr_11 = fn ? => expr (expr_4, expr_9, stmt_6, b_, c_, d_) ?
+      and stmt_3 = fn ? => stmt (stmt_8, expr_2, expr_4, b_, c_, d_) ?
+      and stmt_6 = fn ? => stmt (stmt_5, expr_11, expr_7, d_, c_, b_) ?
+      and expr_7 = fn ? => expr (expr_2, expr_11, stmt_8, c_, d_, b_) ?
       and expr_9 = fn ? => expr (expr_0, expr_7, stmt_10, d_, b_, c_) ?
       and stmt_1 = fn ? => stmt (stmt_10, expr_0, expr_2, c_, d_, b_) ?
-      and stmt_8 = fn ? => stmt (stmt_3, expr_7, expr_9, b_, d_, c_) ?
-      and stmt_6 = fn ? => stmt (stmt_5, expr_11, expr_7, d_, c_, b_) ?
       and stmt_5 = fn ? => stmt (stmt_6, expr_4, expr_0, d_, b_, c_) ?
-      and expr_0 = fn ? => expr (expr_9, expr_4, stmt_1, b_, d_, c_) ?
-      and expr_7 = fn ? => expr (expr_2, expr_11, stmt_8, c_, d_, b_) ?
     in
       (expr_0, stmt_8)
     end
@@ -533,18 +537,18 @@ local
        | ? => ?)
   val expr_stmt = fn (c_, d_, b_) =>
     let
-      val rec stmt_3 = fn ? => stmt (stmt_8, expr_2, expr_4, b_, c_, d_) ?
-      and expr_11 = fn ? => expr (expr_4, expr_9, stmt_6, b_, c_, d_) ?
-      and stmt_10 = fn ? => stmt (stmt_1, expr_9, expr_11, c_, b_, d_) ?
+      val rec expr_0 = fn ? => expr (expr_9, expr_4, stmt_1, b_, d_, c_) ?
       and expr_4 = fn ? => expr (expr_11, expr_2, stmt_5, c_, b_, d_) ?
+      and stmt_8 = fn ? => stmt (stmt_3, expr_7, expr_9, b_, d_, c_) ?
+      and stmt_10 = fn ? => stmt (stmt_1, expr_9, expr_11, c_, b_, d_) ?
       and expr_2 = fn ? => expr (expr_7, expr_0, stmt_3, d_, c_, b_) ?
+      and expr_11 = fn ? => expr (expr_4, expr_9, stmt_6, b_, c_, d_) ?
+      and stmt_3 = fn ? => stmt (stmt_8, expr_2, expr_4, b_, c_, d_) ?
+      and stmt_6 = fn ? => stmt (stmt_5, expr_11, expr_7, d_, c_, b_) ?
+      and expr_7 = fn ? => expr (expr_2, expr_11, stmt_8, c_, d_, b_) ?
       and expr_9 = fn ? => expr (expr_0, expr_7, stmt_10, d_, b_, c_) ?
       and stmt_1 = fn ? => stmt (stmt_10, expr_0, expr_2, c_, d_, b_) ?
-      and stmt_8 = fn ? => stmt (stmt_3, expr_7, expr_9, b_, d_, c_) ?
-      and stmt_6 = fn ? => stmt (stmt_5, expr_11, expr_7, d_, c_, b_) ?
       and stmt_5 = fn ? => stmt (stmt_6, expr_4, expr_0, d_, b_, c_) ?
-      and expr_0 = fn ? => expr (expr_9, expr_4, stmt_1, b_, d_, c_) ?
-      and expr_7 = fn ? => expr (expr_2, expr_11, stmt_8, c_, d_, b_) ?
     in
       (expr_0, stmt_8)
     end
@@ -570,18 +574,18 @@ local
      | _ => false
   val expr_stmt = fn (c_, d_, b_) =>
     let
-      val rec stmt_3 = fn ? => stmt (stmt_8, expr_2, expr_4, b_, c_, d_) ?
-      and expr_11 = fn ? => expr (expr_4, expr_9, stmt_6, b_, c_, d_) ?
-      and stmt_10 = fn ? => stmt (stmt_1, expr_9, expr_11, c_, b_, d_) ?
+      val rec expr_0 = fn ? => expr (expr_9, expr_4, stmt_1, b_, d_, c_) ?
       and expr_4 = fn ? => expr (expr_11, expr_2, stmt_5, c_, b_, d_) ?
+      and stmt_8 = fn ? => stmt (stmt_3, expr_7, expr_9, b_, d_, c_) ?
+      and stmt_10 = fn ? => stmt (stmt_1, expr_9, expr_11, c_, b_, d_) ?
       and expr_2 = fn ? => expr (expr_7, expr_0, stmt_3, d_, c_, b_) ?
+      and expr_11 = fn ? => expr (expr_4, expr_9, stmt_6, b_, c_, d_) ?
+      and stmt_3 = fn ? => stmt (stmt_8, expr_2, expr_4, b_, c_, d_) ?
+      and stmt_6 = fn ? => stmt (stmt_5, expr_11, expr_7, d_, c_, b_) ?
+      and expr_7 = fn ? => expr (expr_2, expr_11, stmt_8, c_, d_, b_) ?
       and expr_9 = fn ? => expr (expr_0, expr_7, stmt_10, d_, b_, c_) ?
       and stmt_1 = fn ? => stmt (stmt_10, expr_0, expr_2, c_, d_, b_) ?
-      and stmt_8 = fn ? => stmt (stmt_3, expr_7, expr_9, b_, d_, c_) ?
-      and stmt_6 = fn ? => stmt (stmt_5, expr_11, expr_7, d_, c_, b_) ?
       and stmt_5 = fn ? => stmt (stmt_6, expr_4, expr_0, d_, b_, c_) ?
-      and expr_0 = fn ? => expr (expr_9, expr_4, stmt_1, b_, d_, c_) ?
-      and expr_7 = fn ? => expr (expr_2, expr_11, stmt_8, c_, d_, b_) ?
     in
       (expr_0, stmt_8)
     end
@@ -639,18 +643,18 @@ local
       end
   val expr_stmt = fn (c_, d_, b_) =>
     let
-      val rec stmt_3 = fn ? => stmt (stmt_8, expr_2, expr_4, b_, c_, d_) ?
-      and expr_11 = fn ? => expr (expr_4, expr_9, stmt_6, b_, c_, d_) ?
-      and stmt_10 = fn ? => stmt (stmt_1, expr_9, expr_11, c_, b_, d_) ?
+      val rec expr_0 = fn ? => expr (expr_9, expr_4, stmt_1, b_, d_, c_) ?
       and expr_4 = fn ? => expr (expr_11, expr_2, stmt_5, c_, b_, d_) ?
+      and stmt_8 = fn ? => stmt (stmt_3, expr_7, expr_9, b_, d_, c_) ?
+      and stmt_10 = fn ? => stmt (stmt_1, expr_9, expr_11, c_, b_, d_) ?
       and expr_2 = fn ? => expr (expr_7, expr_0, stmt_3, d_, c_, b_) ?
+      and expr_11 = fn ? => expr (expr_4, expr_9, stmt_6, b_, c_, d_) ?
+      and stmt_3 = fn ? => stmt (stmt_8, expr_2, expr_4, b_, c_, d_) ?
+      and stmt_6 = fn ? => stmt (stmt_5, expr_11, expr_7, d_, c_, b_) ?
+      and expr_7 = fn ? => expr (expr_2, expr_11, stmt_8, c_, d_, b_) ?
       and expr_9 = fn ? => expr (expr_0, expr_7, stmt_10, d_, b_, c_) ?
       and stmt_1 = fn ? => stmt (stmt_10, expr_0, expr_2, c_, d_, b_) ?
-      and stmt_8 = fn ? => stmt (stmt_3, expr_7, expr_9, b_, d_, c_) ?
-      and stmt_6 = fn ? => stmt (stmt_5, expr_11, expr_7, d_, c_, b_) ?
       and stmt_5 = fn ? => stmt (stmt_6, expr_4, expr_0, d_, b_, c_) ?
-      and expr_0 = fn ? => expr (expr_9, expr_4, stmt_1, b_, d_, c_) ?
-      and expr_7 = fn ? => expr (expr_2, expr_11, stmt_8, c_, d_, b_) ?
     in
       (expr_0, stmt_8)
     end
@@ -674,9 +678,9 @@ val expr_stmt = fn (a_, b_, c_) =>
   let
     open Tie
     val Y = Generic.Y
-    val stmt_3 & _ & _ & expr_0 & _ =
+    val _ & _ & _ & expr_0 & stmt_3 =
       fix (Y *` Y *` Y *` Y *` Y)
-        (fn stmt_3 & stmt_1 & stmt_4 & expr_0 & stmt_2 =>
+        (fn stmt_4 & stmt_1 & stmt_2 & expr_0 & stmt_3 =>
            let
              open Generic
              fun expr (expr_0, stmt_1) =
@@ -698,10 +702,10 @@ val expr_stmt = fn (a_, b_, c_) =>
                  , fn INR ? => If ? | INL ? => Assign ?
                  )
            in
-             stmt (stmt_4, expr_0, c_, b_, a_)
+             stmt (stmt_3, expr_0, c_, a_, b_)
              & stmt (stmt_2, expr_0, real, int, string)
-             & stmt (stmt_3, expr_0, c_, a_, b_) & expr (expr_0, stmt_1)
-             & stmt (stmt_1, expr_0, real, string, int)
+             & stmt (stmt_1, expr_0, real, string, int) & expr (expr_0, stmt_1)
+             & stmt (stmt_4, expr_0, c_, b_, a_)
            end)
   in
     (expr_0, stmt_3)
@@ -729,7 +733,7 @@ local
         ] ^ ")"
   val expr_stmt = fn (a_, b_, c_) =>
     let
-      val rec stmt_3 = fn ? => stmt (stmt_4, expr_0, c_, b_, a_) ?
+      val rec stmt_4 = fn ? => stmt (stmt_3, expr_0, c_, a_, b_) ?
       and stmt_1 = fn ? =>
         stmt
           ( stmt_2
@@ -738,8 +742,6 @@ local
           , Int.toString
           , fn t0 => "\"" ^ t0 ^ "\""
           ) ?
-      and stmt_4 = fn ? => stmt (stmt_3, expr_0, c_, a_, b_) ?
-      and expr_0 = fn ? => expr (expr_0, stmt_1) ?
       and stmt_2 = fn ? =>
         stmt
           ( stmt_1
@@ -748,6 +750,8 @@ local
           , fn t0 => "\"" ^ t0 ^ "\""
           , Int.toString
           ) ?
+      and expr_0 = fn ? => expr (expr_0, stmt_1) ?
+      and stmt_3 = fn ? => stmt (stmt_4, expr_0, c_, b_, a_) ?
     in
       (expr_0, stmt_3)
     end
@@ -792,13 +796,13 @@ local
        | ? => ?)
   val expr_stmt = fn (a_, b_, c_) =>
     let
-      val rec stmt_3 = fn ? => stmt (stmt_4, expr_0, c_, b_, a_) ?
+      val rec stmt_4 = fn ? => stmt (stmt_3, expr_0, c_, a_, b_) ?
       and stmt_1 = fn ? =>
         stmt (stmt_2, expr_0, Real.compare, Int.compare, String.compare) ?
-      and stmt_4 = fn ? => stmt (stmt_3, expr_0, c_, a_, b_) ?
-      and expr_0 = fn ? => expr (expr_0, stmt_1) ?
       and stmt_2 = fn ? =>
         stmt (stmt_1, expr_0, Real.compare, String.compare, Int.compare) ?
+      and expr_0 = fn ? => expr (expr_0, stmt_1) ?
+      and stmt_3 = fn ? => stmt (stmt_4, expr_0, c_, b_, a_) ?
     in
       (expr_0, stmt_3)
     end
@@ -824,11 +828,11 @@ local
      | _ => false
   val expr_stmt = fn (a_, b_, c_) =>
     let
-      val rec stmt_3 = fn ? => stmt (stmt_4, expr_0, c_, b_, a_) ?
+      val rec stmt_4 = fn ? => stmt (stmt_3, expr_0, c_, a_, b_) ?
       and stmt_1 = fn ? => stmt (stmt_2, expr_0, Real.==, op=, op=) ?
-      and stmt_4 = fn ? => stmt (stmt_3, expr_0, c_, a_, b_) ?
-      and expr_0 = fn ? => expr (expr_0, stmt_1) ?
       and stmt_2 = fn ? => stmt (stmt_1, expr_0, Real.==, op=, op=) ?
+      and expr_0 = fn ? => expr (expr_0, stmt_1) ?
+      and stmt_3 = fn ? => stmt (stmt_4, expr_0, c_, b_, a_) ?
     in
       (expr_0, stmt_3)
     end
@@ -881,7 +885,7 @@ local
       end
   val expr_stmt = fn (a_, b_, c_) =>
     let
-      val rec stmt_3 = fn ? => stmt (stmt_4, expr_0, c_, b_, a_) ?
+      val rec stmt_4 = fn ? => stmt (stmt_3, expr_0, c_, a_, b_) ?
       and stmt_1 = fn ? =>
         stmt
           ( stmt_2
@@ -890,8 +894,6 @@ local
           , Word.fromInt
           , hashString
           ) ?
-      and stmt_4 = fn ? => stmt (stmt_3, expr_0, c_, a_, b_) ?
-      and expr_0 = fn ? => expr (expr_0, stmt_1) ?
       and stmt_2 = fn ? =>
         stmt
           ( stmt_1
@@ -900,6 +902,8 @@ local
           , hashString
           , Word.fromInt
           ) ?
+      and expr_0 = fn ? => expr (expr_0, stmt_1) ?
+      and stmt_3 = fn ? => stmt (stmt_4, expr_0, c_, b_, a_) ?
     in
       (expr_0, stmt_3)
     end

--- a/test/test13.sml.expected
+++ b/test/test13.sml.expected
@@ -14,35 +14,23 @@ datatype 'a t =
 
 (* This should also work *)
 local
-  val rec t = fn (t_1, a_) => fn T' t0 => "T' " ^ "(" ^ t_1 t0 ^ ")"
-  val t = fn a_ =>
-    let val rec t_1 = fn ? => t (t_1, a_) ? and t_0 = fn ? => t (t_1, a_) ?
-    in t_0
-    end
+  val rec t = fn (t_0, a_) => fn T' t0 => "T' " ^ "(" ^ t_0 t0 ^ ")"
+  val t = fn a_ => let val rec t_0 = fn ? => t (t_0, a_) ? in t_0 end
 in val show = t
 end
 local
-  val rec t = fn (t_1, a_) => fn (T' t0, T' t1) => t_1 (t0, t1)
-  val t = fn a_ =>
-    let val rec t_1 = fn ? => t (t_1, a_) ? and t_0 = fn ? => t (t_1, a_) ?
-    in t_0
-    end
+  val rec t = fn (t_0, a_) => fn (T' t0, T' t1) => t_0 (t0, t1)
+  val t = fn a_ => let val rec t_0 = fn ? => t (t_0, a_) ? in t_0 end
 in val compare = t
 end
 local
-  val rec t = fn (t_1, a_) => fn (T' t0, T' t1) => t_1 (t0, t1)
-  val t = fn a_ =>
-    let val rec t_1 = fn ? => t (t_1, a_) ? and t_0 = fn ? => t (t_1, a_) ?
-    in t_0
-    end
+  val rec t = fn (t_0, a_) => fn (T' t0, T' t1) => t_0 (t0, t1)
+  val t = fn a_ => let val rec t_0 = fn ? => t (t_0, a_) ? in t_0 end
 in val op== = t
 end
 local
-  val rec t = fn (t_1, a_) => fn T' t0 => t_1 t0
-  val t = fn a_ =>
-    let val rec t_1 = fn ? => t (t_1, a_) ? and t_0 = fn ? => t (t_1, a_) ?
-    in t_0
-    end
+  val rec t = fn (t_0, a_) => fn T' t0 => t_0 t0
+  val t = fn a_ => let val rec t_0 = fn ? => t (t_0, a_) ? in t_0 end
 in val hash = t
 end
 datatype

--- a/test/test14.sml.expected
+++ b/test/test14.sml.expected
@@ -201,8 +201,8 @@ struct
         "TArrow " ^ "(" ^ String.concatWith ", " [typ_1 t2, typ_1 t3] ^ ")"
     val tv_typ = fn () =>
       let
-        val rec typ_1 = fn ? => typ (typ_1, tv_0) ?
-        and tv_0 = fn ? => tv typ_1 ?
+        val rec tv_0 = fn ? => tv typ_1 ?
+        and typ_1 = fn ? => typ (typ_1, tv_0) ?
       in
         (tv_0, typ_1)
       end
@@ -229,8 +229,8 @@ struct
          | ? => ?)
     val tv_typ = fn () =>
       let
-        val rec typ_1 = fn ? => typ (typ_1, tv_0) ?
-        and tv_0 = fn ? => tv typ_1 ?
+        val rec tv_0 = fn ? => tv typ_1 ?
+        and typ_1 = fn ? => typ (typ_1, tv_0) ?
       in
         (tv_0, typ_1)
       end
@@ -249,8 +249,8 @@ struct
        | _ => false
     val tv_typ = fn () =>
       let
-        val rec typ_1 = fn ? => typ (typ_1, tv_0) ?
-        and tv_0 = fn ? => tv typ_1 ?
+        val rec tv_0 = fn ? => tv typ_1 ?
+        and typ_1 = fn ? => typ (typ_1, tv_0) ?
       in
         (tv_0, typ_1)
       end
@@ -282,8 +282,8 @@ struct
         end
     val tv_typ = fn () =>
       let
-        val rec typ_1 = fn ? => typ (typ_1, tv_0) ?
-        and tv_0 = fn ? => tv typ_1 ?
+        val rec tv_0 = fn ? => tv typ_1 ?
+        and typ_1 = fn ? => typ (typ_1, tv_0) ?
       in
         (tv_0, typ_1)
       end

--- a/test/test16.sml.expected
+++ b/test/test16.sml.expected
@@ -307,7 +307,7 @@ val t'_t = fn b_ =>
   let
     open Tie
     val Y = Generic.Y
-    val t'_0 & t_1 = fix (Y *` Y) (fn t'_0 & t_1 =>
+    val t_1 & t'_0 = fix (Y *` Y) (fn t_1 & t'_0 =>
       let
         open Generic
         fun t' (t_1, b_) =
@@ -316,7 +316,7 @@ val t'_t = fn b_ =>
           data' (C1' "T'" t'_0 +` C0' "Nil")
             (fn Nil => INR () | T' ? => INL ?, fn INR () => Nil | INL ? => T' ?)
       in
-        t' (t_1, b_) & t (t'_0, b_)
+        t (t'_0, b_) & t' (t_1, b_)
       end)
   in
     (t'_0, t_1)
@@ -333,7 +333,7 @@ local
   and t = fn (t'_0, b_) =>
     fn T' t0 => "T' " ^ "(" ^ t'_0 t0 ^ ")" | Nil => "Nil"
   val t'_t = fn b_ =>
-    let val rec t'_0 = fn ? => t' (t_1, b_) ? and t_1 = fn ? => t (t'_0, b_) ?
+    let val rec t_1 = fn ? => t (t'_0, b_) ? and t'_0 = fn ? => t' (t_1, b_) ?
     in (t'_0, t_1)
     end
 in val showT' = fn ? => #1 (t'_t ?) val show = fn ? => #2 (t'_t ?)
@@ -357,7 +357,7 @@ local
      | (Nil, T' _) => GREATER
      | (Nil, Nil) => EQUAL
   val t'_t = fn b_ =>
-    let val rec t'_0 = fn ? => t' (t_1, b_) ? and t_1 = fn ? => t (t'_0, b_) ?
+    let val rec t_1 = fn ? => t (t'_0, b_) ? and t'_0 = fn ? => t' (t_1, b_) ?
     in (t'_0, t_1)
     end
 in val compareT' = fn ? => #1 (t'_t ?) val compare = fn ? => #2 (t'_t ?)
@@ -372,7 +372,7 @@ local
   and t = fn (t'_0, b_) =>
     fn (T' t0, T' t1) => t'_0 (t0, t1) | (Nil, Nil) => true | _ => false
   val t'_t = fn b_ =>
-    let val rec t'_0 = fn ? => t' (t_1, b_) ? and t_1 = fn ? => t (t'_0, b_) ?
+    let val rec t_1 = fn ? => t (t'_0, b_) ? and t'_0 = fn ? => t' (t_1, b_) ?
     in (t'_0, t_1)
     end
 in val eqT' = fn ? => #1 (t'_t ?) val op== = fn ? => #2 (t'_t ?)
@@ -395,7 +395,7 @@ local
   and t = fn (t'_0, b_) =>
     fn T' t0 => combine (hashString "T'", t'_0 t0) | Nil => hashString "Nil"
   val t'_t = fn b_ =>
-    let val rec t'_0 = fn ? => t' (t_1, b_) ? and t_1 = fn ? => t (t'_0, b_) ?
+    let val rec t_1 = fn ? => t (t'_0, b_) ? and t'_0 = fn ? => t' (t_1, b_) ?
     in (t'_0, t_1)
     end
 in val hashT' = fn ? => #1 (t'_t ?) val hash = fn ? => #2 (t'_t ?)
@@ -409,8 +409,8 @@ val t'_t = fn (a_, b_) =>
   let
     open Tie
     val Y = Generic.Y
-    val _ & _ & t'_0 & _ & t_2 =
-      fix (Y *` Y *` Y *` Y *` Y) (fn t'_3 & t_4 & t'_0 & t_1 & t_2 =>
+    val t'_0 & _ & t_2 & _ & _ =
+      fix (Y *` Y *` Y *` Y *` Y) (fn t'_0 & t_1 & t_2 & t'_3 & t_4 =>
         let
           open Generic
           fun t' (t_1, a_) = tuple2 (a_, t_1)
@@ -420,8 +420,8 @@ val t'_t = fn (a_, b_) =>
               , fn INR () => Nil | INL ? => T' ?
               )
         in
-          t' (t_4, b_) & t (t'_3, t'_3, b_, b_) & t' (t_1, a_)
-          & t (t'_0, t'_0, a_, a_) & t (t'_3, t'_0, b_, a_)
+          t' (t_1, a_) & t (t'_0, t'_0, a_, a_) & t (t'_3, t'_0, b_, a_)
+          & t' (t_4, b_) & t (t'_3, t'_3, b_, b_)
         end)
   in
     (t'_0, t_2)
@@ -437,11 +437,11 @@ local
      | Nil => "Nil"
   val t'_t = fn (a_, b_) =>
     let
-      val rec t'_3 = fn ? => t' (t_4, b_) ?
-      and t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
-      and t'_0 = fn ? => t' (t_1, a_) ?
+      val rec t'_0 = fn ? => t' (t_1, a_) ?
       and t_1 = fn ? => t (t'_0, t'_0, a_, a_) ?
       and t_2 = fn ? => t (t'_3, t'_0, b_, a_) ?
+      and t'_3 = fn ? => t' (t_4, b_) ?
+      and t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
     in
       (t'_0, t_2)
     end
@@ -463,11 +463,11 @@ local
      | (Nil, Nil) => EQUAL
   val t'_t = fn (a_, b_) =>
     let
-      val rec t'_3 = fn ? => t' (t_4, b_) ?
-      and t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
-      and t'_0 = fn ? => t' (t_1, a_) ?
+      val rec t'_0 = fn ? => t' (t_1, a_) ?
       and t_1 = fn ? => t (t'_0, t'_0, a_, a_) ?
       and t_2 = fn ? => t (t'_3, t'_0, b_, a_) ?
+      and t'_3 = fn ? => t' (t_4, b_) ?
+      and t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
     in
       (t'_0, t_2)
     end
@@ -482,11 +482,11 @@ local
      | _ => false
   val t'_t = fn (a_, b_) =>
     let
-      val rec t'_3 = fn ? => t' (t_4, b_) ?
-      and t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
-      and t'_0 = fn ? => t' (t_1, a_) ?
+      val rec t'_0 = fn ? => t' (t_1, a_) ?
       and t_1 = fn ? => t (t'_0, t'_0, a_, a_) ?
       and t_2 = fn ? => t (t'_3, t'_0, b_, a_) ?
+      and t'_3 = fn ? => t' (t_4, b_) ?
+      and t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
     in
       (t'_0, t_2)
     end
@@ -515,11 +515,11 @@ local
      | Nil => hashString "Nil"
   val t'_t = fn (a_, b_) =>
     let
-      val rec t'_3 = fn ? => t' (t_4, b_) ?
-      and t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
-      and t'_0 = fn ? => t' (t_1, a_) ?
+      val rec t'_0 = fn ? => t' (t_1, a_) ?
       and t_1 = fn ? => t (t'_0, t'_0, a_, a_) ?
       and t_2 = fn ? => t (t'_3, t'_0, b_, a_) ?
+      and t'_3 = fn ? => t' (t_4, b_) ?
+      and t_4 = fn ? => t (t'_3, t'_3, b_, b_) ?
     in
       (t'_0, t_2)
     end
@@ -541,9 +541,9 @@ val t''_t_t' = fn (a_, b_) =>
   let
     open Tie
     val Y = Generic.Y
-    val _ & t'_6 & _ & _ & t_5 & _ & _ & t''_0 & _ & _ =
+    val _ & _ & _ & t'_6 & _ & _ & t''_0 & t_5 & _ & _ =
       fix (Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y)
-        (fn t_7 & t'_6 & t''_8 & t''_4 & t_5 & t_9 & t_3 & t''_0 & t_1 & t'_2 =>
+        (fn t''_8 & t_1 & t_9 & t'_6 & t_7 & t'_2 & t''_0 & t_5 & t''_4 & t_3 =>
            let
              open Generic
              fun t'' (t_1, a_) = tuple2 (t_1, a_)
@@ -554,10 +554,11 @@ val t''_t_t' = fn (a_, b_) =>
                  )
              fun t' (t_7, a_) = tuple2 (a_, t_7)
            in
-             t (t''_4, t'_6, int, a_) & t' (t_7, a_) & t'' (t_9, b_)
-             & t'' (t_3, int) & t (t''_8, t'_6, b_, a_)
-             & t (t''_8, t'_2, b_, string) & t (t''_4, t'_2, int, string)
-             & t'' (t_1, a_) & t (t''_0, t'_2, a_, string) & t' (t_3, string)
+             t'' (t_9, b_) & t (t''_0, t'_2, a_, string)
+             & t (t''_8, t'_2, b_, string) & t' (t_7, a_)
+             & t (t''_4, t'_6, int, a_) & t' (t_3, string) & t'' (t_1, a_)
+             & t (t''_8, t'_6, b_, a_) & t'' (t_3, int)
+             & t (t''_4, t'_2, int, string)
            end)
   in
     (t''_0, t_5, t'_6)
@@ -576,17 +577,17 @@ local
     fn (t0, t1) => "(" ^ String.concatWith ", " [a_ t0, t_7 t1] ^ ")"
   val t''_t_t' = fn (a_, b_) =>
     let
-      val rec t_7 = fn ? => t (t''_4, t'_6, Int.toString, a_) ?
-      and t'_6 = fn ? => t' (t_7, a_) ?
-      and t''_8 = fn ? => t'' (t_9, b_) ?
-      and t''_4 = fn ? => t'' (t_3, Int.toString) ?
-      and t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
+      val rec t''_8 = fn ? => t'' (t_9, b_) ?
+      and t_1 = fn ? => t (t''_0, t'_2, a_, fn t0 => "\"" ^ t0 ^ "\"") ?
       and t_9 = fn ? => t (t''_8, t'_2, b_, fn t0 => "\"" ^ t0 ^ "\"") ?
+      and t'_6 = fn ? => t' (t_7, a_) ?
+      and t_7 = fn ? => t (t''_4, t'_6, Int.toString, a_) ?
+      and t'_2 = fn ? => t' (t_3, fn t0 => "\"" ^ t0 ^ "\"") ?
+      and t''_0 = fn ? => t'' (t_1, a_) ?
+      and t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
+      and t''_4 = fn ? => t'' (t_3, Int.toString) ?
       and t_3 = fn ? =>
         t (t''_4, t'_2, Int.toString, fn t0 => "\"" ^ t0 ^ "\"") ?
-      and t''_0 = fn ? => t'' (t_1, a_) ?
-      and t_1 = fn ? => t (t''_0, t'_2, a_, fn t0 => "\"" ^ t0 ^ "\"") ?
-      and t'_2 = fn ? => t' (t_3, fn t0 => "\"" ^ t0 ^ "\"") ?
     in
       (t''_0, t_5, t'_6)
     end
@@ -616,16 +617,16 @@ local
        | ? => ?)
   val t''_t_t' = fn (a_, b_) =>
     let
-      val rec t_7 = fn ? => t (t''_4, t'_6, Int.compare, a_) ?
-      and t'_6 = fn ? => t' (t_7, a_) ?
-      and t''_8 = fn ? => t'' (t_9, b_) ?
-      and t''_4 = fn ? => t'' (t_3, Int.compare) ?
-      and t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
-      and t_9 = fn ? => t (t''_8, t'_2, b_, String.compare) ?
-      and t_3 = fn ? => t (t''_4, t'_2, Int.compare, String.compare) ?
-      and t''_0 = fn ? => t'' (t_1, a_) ?
+      val rec t''_8 = fn ? => t'' (t_9, b_) ?
       and t_1 = fn ? => t (t''_0, t'_2, a_, String.compare) ?
+      and t_9 = fn ? => t (t''_8, t'_2, b_, String.compare) ?
+      and t'_6 = fn ? => t' (t_7, a_) ?
+      and t_7 = fn ? => t (t''_4, t'_6, Int.compare, a_) ?
       and t'_2 = fn ? => t' (t_3, String.compare) ?
+      and t''_0 = fn ? => t'' (t_1, a_) ?
+      and t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
+      and t''_4 = fn ? => t'' (t_3, Int.compare) ?
+      and t_3 = fn ? => t (t''_4, t'_2, Int.compare, String.compare) ?
     in
       (t''_0, t_5, t'_6)
     end
@@ -645,16 +646,16 @@ local
     fn ((t0, t1), (t2, t3)) => a_ (t0, t2) andalso t_7 (t1, t3)
   val t''_t_t' = fn (a_, b_) =>
     let
-      val rec t_7 = fn ? => t (t''_4, t'_6, op=, a_) ?
-      and t'_6 = fn ? => t' (t_7, a_) ?
-      and t''_8 = fn ? => t'' (t_9, b_) ?
-      and t''_4 = fn ? => t'' (t_3, op=) ?
-      and t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
-      and t_9 = fn ? => t (t''_8, t'_2, b_, op=) ?
-      and t_3 = fn ? => t (t''_4, t'_2, op=, op=) ?
-      and t''_0 = fn ? => t'' (t_1, a_) ?
+      val rec t''_8 = fn ? => t'' (t_9, b_) ?
       and t_1 = fn ? => t (t''_0, t'_2, a_, op=) ?
+      and t_9 = fn ? => t (t''_8, t'_2, b_, op=) ?
+      and t'_6 = fn ? => t' (t_7, a_) ?
+      and t_7 = fn ? => t (t''_4, t'_6, op=, a_) ?
       and t'_2 = fn ? => t' (t_3, op=) ?
+      and t''_0 = fn ? => t'' (t_1, a_) ?
+      and t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
+      and t''_4 = fn ? => t'' (t_3, op=) ?
+      and t_3 = fn ? => t (t''_4, t'_2, op=, op=) ?
     in
       (t''_0, t_5, t'_6)
     end
@@ -687,16 +688,16 @@ local
   and t' = fn (t_7, a_) => fn (t0, t1) => combine (a_ t0, t_7 t1)
   val t''_t_t' = fn (a_, b_) =>
     let
-      val rec t_7 = fn ? => t (t''_4, t'_6, Word.fromInt, a_) ?
-      and t'_6 = fn ? => t' (t_7, a_) ?
-      and t''_8 = fn ? => t'' (t_9, b_) ?
-      and t''_4 = fn ? => t'' (t_3, Word.fromInt) ?
-      and t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
-      and t_9 = fn ? => t (t''_8, t'_2, b_, hashString) ?
-      and t_3 = fn ? => t (t''_4, t'_2, Word.fromInt, hashString) ?
-      and t''_0 = fn ? => t'' (t_1, a_) ?
+      val rec t''_8 = fn ? => t'' (t_9, b_) ?
       and t_1 = fn ? => t (t''_0, t'_2, a_, hashString) ?
+      and t_9 = fn ? => t (t''_8, t'_2, b_, hashString) ?
+      and t'_6 = fn ? => t' (t_7, a_) ?
+      and t_7 = fn ? => t (t''_4, t'_6, Word.fromInt, a_) ?
       and t'_2 = fn ? => t' (t_3, hashString) ?
+      and t''_0 = fn ? => t'' (t_1, a_) ?
+      and t_5 = fn ? => t (t''_8, t'_6, b_, a_) ?
+      and t''_4 = fn ? => t'' (t_3, Word.fromInt) ?
+      and t_3 = fn ? => t (t''_4, t'_2, Word.fromInt, hashString) ?
     in
       (t''_0, t_5, t'_6)
     end

--- a/test/test2.sml.expected
+++ b/test/test2.sml.expected
@@ -11,10 +11,10 @@ val expr_stmt = fn (b_, a_) =>
   let
     open Tie
     val Y = Generic.Y
-    val _ & _ & _ & _ & expr_0 & _ & _ & stmt_6 =
+    val _ & _ & _ & _ & expr_0 & _ & stmt_6 & _ =
       fix (Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y)
-        (fn expr_3 & expr_2 & expr_5 & stmt_7 & expr_0 & stmt_4 & stmt_1 &
-             stmt_6 =>
+        (fn expr_2 & expr_3 & stmt_1 & stmt_7 & expr_0 & expr_5 & stmt_6 &
+             stmt_4 =>
            let
              open Generic
              fun expr (expr_3, expr_0, stmt_1, a_, b_) =
@@ -36,14 +36,14 @@ val expr_stmt = fn (b_, a_) =>
                  , fn INR ? => If ? | INL ? => Assign ?
                  )
            in
-             expr (expr_0, expr_3, stmt_4, b_, a_)
-             & expr (expr_2, expr_2, stmt_1, a_, a_)
-             & expr (expr_5, expr_5, stmt_4, b_, b_)
+             expr (expr_2, expr_2, stmt_1, a_, a_)
+             & expr (expr_0, expr_3, stmt_4, b_, a_)
+             & stmt (stmt_1, stmt_1, expr_2, a_, a_)
              & stmt (stmt_7, stmt_6, expr_3, b_, a_)
              & expr (expr_3, expr_0, stmt_1, a_, b_)
-             & stmt (stmt_4, stmt_4, expr_5, b_, b_)
-             & stmt (stmt_1, stmt_1, expr_2, a_, a_)
+             & expr (expr_5, expr_5, stmt_4, b_, b_)
              & stmt (stmt_6, stmt_7, expr_0, a_, b_)
+             & stmt (stmt_4, stmt_4, expr_5, b_, b_)
            end)
   in
     (expr_0, stmt_6)
@@ -63,15 +63,15 @@ val expr_stmt = fn (c_, d_) =>
     open Tie
     val Y = Generic.Y
     val
-      _ & expr_0 & _ & _ & _ & _ & _ & _ & _ & _ & stmt_20 & _ & _ & _ & _ & _ &
-        _ & _ & _ & _ & _ & _ =
+      _ & _ & _ & _ & stmt_20 & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ & _ &
+        _ & _ & _ & expr_0 & _ =
       fix
         (Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y
          *` Y *` Y *` Y *` Y *` Y *` Y *` Y)
-        (fn expr_19 & expr_0 & stmt_1 & expr_7 & stmt_14 & expr_15 & expr_6 &
-             expr_12 & expr_3 & expr_17 & stmt_20 & expr_13 & stmt_5 & expr_18 &
-             expr_10 & expr_9 & stmt_21 & expr_16 & expr_4 & stmt_8 & expr_11 &
-             expr_2 =>
+        (fn expr_17 & stmt_1 & expr_11 & expr_18 & stmt_20 & expr_13 & expr_15 &
+             stmt_21 & stmt_14 & expr_12 & expr_3 & expr_10 & expr_6 & expr_9 &
+             expr_7 & stmt_5 & stmt_8 & expr_19 & expr_16 & expr_2 & expr_0 &
+             expr_4 =>
            let
              open Generic
              fun expr (expr_0, expr_13, stmt_1, d_, c_) =
@@ -93,28 +93,28 @@ val expr_stmt = fn (c_, d_) =>
                  , fn INR ? => If ? | INL ? => Assign ?
                  )
            in
-             expr (expr_19, expr_18, stmt_14, string, d_)
-             & expr (expr_0, expr_13, stmt_1, d_, c_)
+             expr (expr_17, expr_16, stmt_5, d_, int)
              & stmt (stmt_1, stmt_1, expr_2, expr_11, expr_3, c_, c_)
-             & expr (expr_7, expr_10, stmt_8, int, string)
-             & stmt (stmt_14, stmt_14, expr_15, expr_18, expr_16, d_, d_)
-             & expr (expr_15, expr_15, stmt_14, d_, d_)
-             & expr (expr_6, expr_6, stmt_5, int, int)
-             & expr (expr_12, expr_11, stmt_1, string, c_)
-             & expr (expr_3, expr_4, stmt_1, int, c_)
-             & expr (expr_17, expr_16, stmt_5, d_, int)
+             & expr (expr_11, expr_12, stmt_8, c_, string)
+             & expr (expr_18, expr_19, stmt_8, d_, string)
              & stmt (stmt_20, stmt_21, expr_0, expr_18, expr_3, d_, c_)
              & expr (expr_13, expr_0, stmt_14, c_, d_)
-             & stmt (stmt_5, stmt_5, expr_6, expr_7, expr_6, int, int)
-             & expr (expr_18, expr_19, stmt_8, d_, string)
-             & expr (expr_10, expr_7, stmt_5, string, int)
-             & expr (expr_9, expr_9, stmt_8, string, string)
+             & expr (expr_15, expr_15, stmt_14, d_, d_)
              & stmt (stmt_21, stmt_20, expr_13, expr_11, expr_16, c_, d_)
-             & expr (expr_16, expr_17, stmt_14, int, d_)
-             & expr (expr_4, expr_3, stmt_5, c_, int)
+             & stmt (stmt_14, stmt_14, expr_15, expr_18, expr_16, d_, d_)
+             & expr (expr_12, expr_11, stmt_1, string, c_)
+             & expr (expr_3, expr_4, stmt_1, int, c_)
+             & expr (expr_10, expr_7, stmt_5, string, int)
+             & expr (expr_6, expr_6, stmt_5, int, int)
+             & expr (expr_9, expr_9, stmt_8, string, string)
+             & expr (expr_7, expr_10, stmt_8, int, string)
+             & stmt (stmt_5, stmt_5, expr_6, expr_7, expr_6, int, int)
              & stmt (stmt_8, stmt_8, expr_9, expr_9, expr_7, string, string)
-             & expr (expr_11, expr_12, stmt_8, c_, string)
+             & expr (expr_19, expr_18, stmt_14, string, d_)
+             & expr (expr_16, expr_17, stmt_14, int, d_)
              & expr (expr_2, expr_2, stmt_1, c_, c_)
+             & expr (expr_0, expr_13, stmt_1, d_, c_)
+             & expr (expr_4, expr_3, stmt_5, c_, int)
            end)
   in
     (expr_0, stmt_20)
@@ -134,14 +134,14 @@ val expr_stmt = fn (a_, b_) =>
     open Tie
     val Y = Generic.Y
     val
-      _ & _ & _ & _ & _ & _ & stmt_11 & _ & expr_0 & _ & _ & _ & _ & _ & _ & _ &
+      _ & _ & _ & _ & _ & _ & expr_0 & _ & _ & stmt_11 & _ & _ & _ & _ & _ & _ &
         _ & _ =
       fix
         (Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y
          *` Y *` Y *` Y)
-        (fn stmt_8 & stmt_9 & stmt_16 & expr_2 & expr_12 & stmt_10 & stmt_11 &
-             stmt_3 & expr_0 & stmt_4 & stmt_14 & stmt_15 & stmt_6 & expr_5 &
-             stmt_13 & stmt_1 & stmt_17 & stmt_7 =>
+        (fn stmt_8 & stmt_14 & stmt_9 & stmt_15 & stmt_10 & stmt_1 & expr_0 &
+             stmt_16 & stmt_13 & stmt_11 & expr_5 & expr_2 & stmt_7 & stmt_17 &
+             stmt_3 & stmt_6 & stmt_4 & expr_12 =>
            let
              open Generic
              fun expr (expr_0, stmt_9, stmt_1, a_) =
@@ -164,23 +164,23 @@ val expr_stmt = fn (a_, b_) =>
                  )
            in
              stmt (stmt_8, stmt_1, expr_0, expr_2, a_, int)
-             & stmt (stmt_9, stmt_10, expr_0, expr_5, a_, string)
-             & stmt (stmt_16, stmt_15, expr_5, expr_12, string, b_)
-             & expr (expr_2, stmt_4, stmt_3, int)
-             & expr (expr_12, stmt_15, stmt_13, b_)
-             & stmt (stmt_10, stmt_9, expr_5, expr_0, string, a_)
-             & stmt (stmt_11, stmt_17, expr_12, expr_0, b_, a_)
-             & stmt (stmt_3, stmt_3, expr_2, expr_2, int, int)
-             & expr (expr_0, stmt_9, stmt_1, a_)
-             & stmt (stmt_4, stmt_7, expr_2, expr_5, int, string)
              & stmt (stmt_14, stmt_13, expr_12, expr_2, b_, int)
+             & stmt (stmt_9, stmt_10, expr_0, expr_5, a_, string)
              & stmt (stmt_15, stmt_16, expr_12, expr_5, b_, string)
-             & stmt (stmt_6, stmt_6, expr_5, expr_5, string, string)
-             & expr (expr_5, stmt_6, stmt_4, string)
-             & stmt (stmt_13, stmt_14, expr_2, expr_12, int, b_)
+             & stmt (stmt_10, stmt_9, expr_5, expr_0, string, a_)
              & stmt (stmt_1, stmt_8, expr_2, expr_0, int, a_)
-             & stmt (stmt_17, stmt_11, expr_0, expr_12, a_, b_)
+             & expr (expr_0, stmt_9, stmt_1, a_)
+             & stmt (stmt_16, stmt_15, expr_5, expr_12, string, b_)
+             & stmt (stmt_13, stmt_14, expr_2, expr_12, int, b_)
+             & stmt (stmt_11, stmt_17, expr_12, expr_0, b_, a_)
+             & expr (expr_5, stmt_6, stmt_4, string)
+             & expr (expr_2, stmt_4, stmt_3, int)
              & stmt (stmt_7, stmt_4, expr_5, expr_2, string, int)
+             & stmt (stmt_17, stmt_11, expr_0, expr_12, a_, b_)
+             & stmt (stmt_3, stmt_3, expr_2, expr_2, int, int)
+             & stmt (stmt_6, stmt_6, expr_5, expr_5, string, string)
+             & stmt (stmt_4, stmt_7, expr_2, expr_5, int, string)
+             & expr (expr_12, stmt_15, stmt_13, b_)
            end)
   in
     (expr_0, stmt_11)
@@ -193,15 +193,15 @@ val t = fn a_ =>
   let
     open Tie
     val Y = Generic.Y
-    val _ & _ & t_0 = fix (Y *` Y *` Y) (fn t_2 & t_1 & t_0 =>
+    val t_0 & _ & _ = fix (Y *` Y *` Y) (fn t_0 & t_2 & t_1 =>
       let
         open Generic
         fun t (t_2, t_1, t_0, a_) =
           data' (C1' "T'" (tuple4 (a_, t_0, t_1, t_2))) (fn T' ? => ?, fn ? =>
             T' ?)
       in
-        t (t_2, t_1, t_2, string) & t (t_2, t_1, t_1, int)
-        & t (t_2, t_1, t_0, a_)
+        t (t_2, t_1, t_0, a_) & t (t_2, t_1, t_2, string)
+        & t (t_2, t_1, t_1, int)
       end)
   in
     t_0

--- a/test/test3.sml.expected
+++ b/test/test3.sml.expected
@@ -24,10 +24,10 @@ val expr_stmt = fn (b_, a_) =>
   let
     open Tie
     val Y = Generic.Y
-    val _ & _ & _ & _ & expr_0 & _ & _ & stmt_6 =
+    val _ & _ & _ & _ & expr_0 & _ & stmt_6 & _ =
       fix (Y *` Y *` Y *` Y *` Y *` Y *` Y *` Y)
-        (fn expr_3 & expr_2 & expr_5 & stmt_7 & expr_0 & stmt_4 & stmt_1 &
-             stmt_6 =>
+        (fn expr_2 & expr_3 & stmt_1 & stmt_7 & expr_0 & expr_5 & stmt_6 &
+             stmt_4 =>
            let
              open Generic
              fun expr (*24*) (expr_3, expr_0, stmt_1, a_, b_) =
@@ -51,14 +51,14 @@ val expr_stmt = fn (b_, a_) =>
                  , fn INR ? => If (*t*) ? | INL ? => Assign (*i*) ?
                  )
            in
-             expr (expr_0, expr_3, stmt_4, b_, a_)
-             & expr (expr_2, expr_2, stmt_1, a_, a_)
-             & expr (expr_5, expr_5, stmt_4, b_, b_)
+             expr (expr_2, expr_2, stmt_1, a_, a_)
+             & expr (expr_0, expr_3, stmt_4, b_, a_)
+             & stmt (stmt_1, stmt_1, expr_2, a_, a_)
              & stmt (stmt_7, stmt_6, expr_3, b_, a_)
              & expr (expr_3, expr_0, stmt_1, a_, b_)
-             & stmt (stmt_4, stmt_4, expr_5, b_, b_)
-             & stmt (stmt_1, stmt_1, expr_2, a_, a_)
+             & expr (expr_5, expr_5, stmt_4, b_, b_)
              & stmt (stmt_6, stmt_7, expr_0, a_, b_)
+             & stmt (stmt_4, stmt_4, expr_5, b_, b_)
            end)
   in
     (expr_0, stmt_6)

--- a/test/test5.sml.expected
+++ b/test/test5.sml.expected
@@ -26,14 +26,14 @@ local
         ] ^ ")"
   val expr_stmt = fn (a_, b_) =>
     let
-      val rec expr_0 = fn ? => expr (expr_0, expr_3, stmt_1, b_, a_) ?
-      and expr_2 = fn ? => expr (expr_2, expr_2, stmt_1, a_, a_) ?
-      and expr_5 = fn ? => expr (expr_5, expr_5, stmt_4, b_, b_) ?
+      val rec expr_2 = fn ? => expr (expr_2, expr_2, stmt_1, a_, a_) ?
+      and expr_0 = fn ? => expr (expr_0, expr_3, stmt_1, b_, a_) ?
+      and stmt_1 = fn ? => stmt (stmt_1, stmt_1, expr_2, a_, a_) ?
       and stmt_6 = fn ? => stmt (stmt_6, stmt_7, expr_0, b_, a_) ?
       and expr_3 = fn ? => expr (expr_3, expr_0, stmt_4, a_, b_) ?
-      and stmt_4 = fn ? => stmt (stmt_4, stmt_4, expr_5, b_, b_) ?
-      and stmt_1 = fn ? => stmt (stmt_1, stmt_1, expr_2, a_, a_) ?
+      and expr_5 = fn ? => expr (expr_5, expr_5, stmt_4, b_, b_) ?
       and stmt_7 = fn ? => stmt (stmt_7, stmt_6, expr_3, a_, b_) ?
+      and stmt_4 = fn ? => stmt (stmt_4, stmt_4, expr_5, b_, b_) ?
     in
       (expr_0, stmt_6)
     end

--- a/test/test9.sml.expected
+++ b/test/test9.sml.expected
@@ -42,14 +42,14 @@ local
        | ? => ?)
   val expr_stmt = fn (a_, b_) =>
     let
-      val rec expr_0 = fn ? => expr (expr_0, expr_3, stmt_1, b_, a_) ?
-      and expr_2 = fn ? => expr (expr_2, expr_2, stmt_1, a_, a_) ?
-      and expr_5 = fn ? => expr (expr_5, expr_5, stmt_4, b_, b_) ?
+      val rec expr_2 = fn ? => expr (expr_2, expr_2, stmt_1, a_, a_) ?
+      and expr_0 = fn ? => expr (expr_0, expr_3, stmt_1, b_, a_) ?
+      and stmt_1 = fn ? => stmt (stmt_1, stmt_1, expr_2, a_, a_) ?
       and stmt_6 = fn ? => stmt (stmt_6, stmt_7, expr_0, b_, a_) ?
       and expr_3 = fn ? => expr (expr_3, expr_0, stmt_4, a_, b_) ?
-      and stmt_4 = fn ? => stmt (stmt_4, stmt_4, expr_5, b_, b_) ?
-      and stmt_1 = fn ? => stmt (stmt_1, stmt_1, expr_2, a_, a_) ?
+      and expr_5 = fn ? => expr (expr_5, expr_5, stmt_4, b_, b_) ?
       and stmt_7 = fn ? => stmt (stmt_7, stmt_6, expr_3, a_, b_) ?
+      and stmt_4 = fn ? => stmt (stmt_4, stmt_4, expr_5, b_, b_) ?
     in
       (expr_0, stmt_6)
     end


### PR DESCRIPTION
Currently, in order to hash smlfmt's `Ast.Ty.ty` type, the type is first converted into a string with the `showTy` function, and then it is hashed into an atom. This atom is then passed around for use in `AtomTable` hashtables. This PR generates hash and equality functions on the `Ast.Ty.ty` type directly, avoiding the extra step of converting the type to a string.

Pros:
* It dogfoods the equality and hash generators on the smlfmt's `Ast.Ty.ty` type.
* The hashtables are more type safe since they take in an `Ast.Ty.ty` as a key instead of any atom.
* Don't need to build a string in order to hash a type or check type equality.
* Prevents multiple functions for converting an `Ast.Ty.ty` to a string. `showTy` was compressed for hashing and equality purposes while minimizing space, and `prettyTy` was the pretty version for printing purposes. This is more confusing than direct hashing and equality functions for `Ast.Ty.ty`.

Cons:
* Appears to be slightly less efficient because it hashes multiple times whereas with atoms you only hash once and then use the hashed value multiple times in the table.
* More code (although most of the code is automatically generated).
* Collisions could be more likely since converting a string into an atom uses FNVHash compared to the simple hashing done by the generated hash function.