### PR TITLE
Interactive mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Deps.smlnet
 .smlnetobj
 *.il
 *.exe
+smldotnet/bin
+smldotnet/obj

--- a/Main.sml
+++ b/Main.sml
@@ -37,7 +37,9 @@ struct
     \\n\
     \Generate new project usage: -proj [dirname]\n\n"
 
-  fun filterToken tokenString ((token' :: path, actions) :: xs) =
+  fun filterToken tokenString ((action as (["*"], _)) :: xs) =
+        action :: filterToken tokenString xs
+    | filterToken tokenString ((token' :: path, actions) :: xs) =
         if token' = tokenString then
           (path, actions) :: filterToken tokenString xs
         else
@@ -45,7 +47,8 @@ struct
     | filterToken tokenString (_ :: xs) = filterToken tokenString xs
     | filterToken _ [] = []
 
-  fun getActions tokenString (([token'], actions) :: xs) =
+  fun getActions _ ((["*"], actions) :: _) = SOME actions
+    | getActions tokenString (([token'], actions) :: xs) =
         if token' = tokenString then SOME actions else getActions tokenString xs
     | getActions tokenString (_ :: xs) = getActions tokenString xs
     | getActions _ [] = NONE
@@ -68,18 +71,21 @@ struct
     | lookupGen ch =
         raise Fail ("unknown lookup character: " ^ Char.toString ch)
 
-  fun printToken t =
-    ( print (Token.toString t ^ ":")
-    ; print
+  fun printToken path t =
+    let
+      val t' = String.concatWith "." (List.rev (Token.toString t :: path))
+    in
+      print (t' ^ ":");
+      print
         (Int.toString (#line (Source.absoluteEnd (Token.getSource t))) ^ " ")
-    )
-  fun printDecTypes (Ast.Exp.DecType {typbind = {elems, ...}, ...}) =
-        ArraySlice.app (fn e => printToken (#tycon e)) elems
-    | printDecTypes (Ast.Exp.DecDatatype {datbind = {elems, ...}, ...}) =
-        ArraySlice.app (fn e => printToken (#tycon e)) elems
-    | printDecTypes (Ast.Exp.DecReplicateDatatype {left_id, ...}) =
-        printToken left_id
-    | printDecTypes _ = raise Fail "Unknown declaration type"
+    end
+  fun printDecTypes path (Ast.Exp.DecType {typbind = {elems, ...}, ...}) =
+        ArraySlice.app (fn e => printToken path (#tycon e)) elems
+    | printDecTypes path (Ast.Exp.DecDatatype {datbind = {elems, ...}, ...}) =
+        ArraySlice.app (fn e => printToken path (#tycon e)) elems
+    | printDecTypes path (Ast.Exp.DecReplicateDatatype {left_id, ...}) =
+        printToken path left_id
+    | printDecTypes _ _ = raise Fail "Unknown declaration type"
 
   fun datbindActions args : Ast.Exp.datbind -> Utils.gen option =
     Option.join
@@ -139,26 +145,27 @@ struct
             end
       )
 
-  fun goDecType (opts: Options.opts) (args, dec, typbind) =
+  fun goDecType (opts: Options.opts) ((args, path), dec, typbind) =
     case typbindActions args typbind of
       SOME action =>
         ( print "Types: "
-        ; printDecTypes dec
+        ; printDecTypes path dec
         ; confirm opts dec (fn () => #genTypebind action typbind)
         )
     | NONE => dec
 
   type args = (string list * Utils.gen) list
 
-  fun visitor (opts: Options.opts) (args: args) : args AstVisitor.visitor =
-    { state = args
+  fun visitor (opts: Options.opts) (args: args) :
+    (args * string list) AstVisitor.visitor =
+    { state = (args, [])
     , goDecType = goDecType opts
-    , goDecReplicateDatatype = fn (args, dec, left, right) =>
+    , goDecReplicateDatatype = fn (state, dec, left, right) =>
         let val typbind = BuildAst.replicateDatatypeToTypbind left right
-        in goDecType opts (args, dec, typbind)
+        in goDecType opts (state, dec, typbind)
         end
     , goDecDatatype =
-        fn (args, dec, datbind, withtypee: AstVisitor.withtypee) =>
+        fn ((args, path), dec, datbind, withtypee: AstVisitor.withtypee) =>
           let
             val actions1 = datbindActions args datbind
             val actions2 = Option.join
@@ -171,14 +178,20 @@ struct
             case actions of
               SOME action =>
                 ( print "Types: "
-                ; printDecTypes dec
+                ; printDecTypes path dec
                 ; confirm opts dec (fn () =>
                     #genDatabind action datbind (Option.map #typbind withtypee))
                 )
             | NONE => dec
           end
-    , onStructure = fn strid => filterToken (Token.toString strid)
-    , onFunctor = fn funid => filterToken (Token.toString funid)
+    , onStructure = fn strid =>
+        fn (args, path) => let val strid = Token.toString strid
+                           in (filterToken strid args, strid :: path)
+                           end
+    , onFunctor = fn funid =>
+        fn (args, path) => let val funid = Token.toString funid
+                           in (filterToken funid args, funid :: path)
+                           end
     }
 
   fun gen (opts: Options.opts) (args: args) (Ast.Ast topdecs : Ast.t) =
@@ -245,14 +258,10 @@ struct
       case result of
         Parser.Ast ast =>
           let
-            val args = ["foo:s"]
+            val args = ["*:s"]
             val args: args = List.map parseArg args
-            val ast = gen opts args ast
-            val prettyAst = fn colors =>
-              TerminalColorString.toString {colors = colors} (Utils.pretty ast)
+            val _ = gen opts args ast
           in
-            print (prettyAst true);
-            print "\n";
             doInteractive opts
           end
       | _ => (print "Just comments... Skipping\n"; doInteractive opts)

--- a/Options.sml
+++ b/Options.sml
@@ -14,11 +14,12 @@ struct
     , defaultTableSize: int
     , maxExpDepth: int
     , help: bool
+    , interactive: bool
     }
   fun updateOpts r =
     let
       fun from test printOnly recursiveModules fileGen projGen maxSize
-        defaultTableSize maxExpDepth help =
+        defaultTableSize maxExpDepth help interactive =
         { test = test
         , printOnly = printOnly
         , recursiveModules = recursiveModules
@@ -28,6 +29,7 @@ struct
         , defaultTableSize = defaultTableSize
         , maxExpDepth = maxExpDepth
         , help = help
+        , interactive = interactive
         }
       fun to ?
         { test
@@ -39,11 +41,12 @@ struct
         , defaultTableSize
         , maxExpDepth
         , help
+        , interactive
         } =
         ?test printOnly recursiveModules fileGen projGen maxSize
-          defaultTableSize maxExpDepth help
+          defaultTableSize maxExpDepth help interactive
     in
-      FunctionalRecordUpdate.makeUpdate9 (from, from, to) r
+      FunctionalRecordUpdate.makeUpdate10 (from, from, to) r
     end
   val defaultOpts: opts =
     { test = false
@@ -55,6 +58,7 @@ struct
     , defaultTableSize = !defaultTableSize
     , maxExpDepth = !maxExpDepth
     , help = false
+    , interactive = false
     }
 
   val opts = let open Fold FunctionalRecordUpdate
@@ -77,6 +81,8 @@ struct
         CommandLineArgs.parseInt "tablesize" (!defaultTableSize)
     , maxExpDepth = CommandLineArgs.parseInt "maxexpdepth" (!maxExpDepth)
     , help = CommandLineArgs.parseFlag "help" orelse parseFlag' "h"
+    , interactive =
+        CommandLineArgs.parseFlag "interactive" orelse parseFlag' "i"
     }
 
   (* Similar to CommandLineArgs.positional () but handles shortened args like -p *)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,21 @@ To build the project in [SML.NET](https://github.com/DarinM223/smldotnet), run:
 $SMLNETPATH/bin/smlnet.sh @Smlgen
 ```
 
-the resulting program is `SmldotnetMain.exe` which can be ran like `mono SmldotnetMain.exe ...`.
+the resulting program is `SmldotnetMain.exe` which can be ran with Mono
+like `mono SmldotnetMain.exe ...`.
+
+To run the SML.NET compiled executable with .NET Core, run:
+
+```
+cd smldotnet/
+dotnet build
+./build_net_core.sh
+```
+
+Then `dotnet smlgen.exe` will run smlgen with the .NET Core runtime. With .NET Core, there
+are currently some differences when it comes to reading input. One Ctrl-D will count as an
+Enter key when submitting input and three Ctrl-Ds will count as one Ctrl-D input.
+
 
 Running
 -------

--- a/smldotnet/Program.cs
+++ b/smldotnet/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/smldotnet/build_net_core.sh
+++ b/smldotnet/build_net_core.sh
@@ -1,4 +1,5 @@
 cp ../SmldotnetMain.exe bin/Debug/net8.0/SmldotnetMain.exe
+rm -f -- smlgen.exe
 ln -s bin/Debug/net8.0/SmldotnetMain.exe smlgen.exe
 cd bin/Debug/net8.0
 cp smldotnet.deps.json SmldotnetMain.deps.json

--- a/smldotnet/build_net_core.sh
+++ b/smldotnet/build_net_core.sh
@@ -1,0 +1,5 @@
+cp ../SmldotnetMain.exe bin/Debug/net8.0/SmldotnetMain.exe
+ln -s bin/Debug/net8.0/SmldotnetMain.exe smlgen.exe
+cd bin/Debug/net8.0
+cp smldotnet.deps.json SmldotnetMain.deps.json
+cp smldotnet.runtimeconfig.json SmldotnetMain.runtimeconfig.json

--- a/smldotnet/smldotnet.csproj
+++ b/smldotnet/smldotnet.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
+  </ItemGroup>
+
+</Project>

--- a/smlgen.cm
+++ b/smlgen.cm
@@ -8,6 +8,7 @@ Group is
   ./smlfmt/src/lex/sources.cm
   ./smlfmt/src/parse/sources.cm
   ./smlfmt/src/prettier-print/sources.cm
+  ./smlfmt/src/syntax-highlighting/sources.cm
   SmlfmtWrappers.sml
   Options.sml
   BuildAst.sig

--- a/smlgen.mlb
+++ b/smlgen.mlb
@@ -7,6 +7,7 @@ local
     ./smlfmt/src/lex/sources.mlb
     ./smlfmt/src/parse/sources.mlb
     ./smlfmt/src/prettier-print/sources.mlb
+    ./smlfmt/src/syntax-highlighting/sources.mlb
   end
   SmlfmtWrappers.sml
   Fold.sml


### PR DESCRIPTION
Adds interactive mode which allows you to input your datatypes to generate code for directly instead of having to create a new file. This can be helpful if only part of the file is parsable as SML because of non-standard extensions.

Also allows for specifying generator paths with wildcards, like `Foo.*` or `*`.

Adds scripts to run the executable created from SML.NET with .NET Core 8.